### PR TITLE
f/HYDRA-1187 - Make data table collapsible animation

### DIFF
--- a/packages/ui/src/components/DataTable/DataTable.styled.ts
+++ b/packages/ui/src/components/DataTable/DataTable.styled.ts
@@ -1,5 +1,6 @@
 import { css } from "@emotion/react"
 
+import { Box } from "@/components/Box"
 import { Flex } from "@/components/Flex"
 import { styled } from "@/utils"
 
@@ -11,5 +12,18 @@ export const SPagination = styled(Flex)(
     justify-content: center;
     padding: 10px;
     border-top: 1px solid ${theme.details.separators};
+  `,
+)
+
+export const SCollapsible = styled(Box)(
+  () => css`
+    interpolate-size: allow-keywords;
+
+    @starting-style {
+      height: 0px;
+    }
+
+    height: max-content;
+    transition: height 0.3s ease;
   `,
 )

--- a/packages/ui/src/components/DataTable/DataTable.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.tsx
@@ -23,7 +23,10 @@ import {
 
 import { Box } from "@/components/Box"
 import { Button } from "@/components/Button"
-import { SPagination } from "@/components/DataTable/DataTable.styled"
+import {
+  SCollapsible,
+  SPagination,
+} from "@/components/DataTable/DataTable.styled"
 import { ExternalLink } from "@/components/ExternalLink"
 import { Flex } from "@/components/Flex"
 import { Icon } from "@/components/Icon"
@@ -293,7 +296,11 @@ const DataTable = forwardRef(
                         <TableCell
                           colSpan={table.getVisibleLeafColumns().length + 1}
                         >
-                          <Box py={16}>{renderSubComponent(row.original)}</Box>
+                          <SCollapsible>
+                            <Box py={16}>
+                              {renderSubComponent(row.original)}
+                            </Box>
+                          </SCollapsible>
                         </TableCell>
                       </TableRow>
                     )}


### PR DESCRIPTION
Doesn't work on Safari or Firefox but I did not find a better way without breaking table layout without spending too much time on it. Safari should catch up with css to 2024 baseline lol.