### PR TITLE
Subscribe to Nova Wallet account changes

### DIFF
--- a/src/sections/transaction/ReviewTransactionError.tsx
+++ b/src/sections/transaction/ReviewTransactionError.tsx
@@ -11,10 +11,11 @@ import { useAccount } from "sections/web3-connect/Web3Connect.utils"
 import { useRpcProvider } from "providers/rpcProvider"
 import { useActiveProvider } from "api/provider"
 import { useBestNumber } from "api/chain"
+import { TransactionError } from "sections/transaction/ReviewTransaction.utils"
 import {
-  TransactionError,
-  TTxErrorData,
-} from "sections/transaction/ReviewTransaction.utils"
+  getErrorTemplate,
+  parseErrorMessage,
+} from "sections/transaction/ReviewTransactionError.utils"
 
 type ReviewTransactionErrorProps = {
   onClose: () => void
@@ -109,24 +110,4 @@ export const ReviewTransactionError: FC<ReviewTransactionErrorProps> = ({
       </div>
     </div>
   )
-}
-
-function parseErrorMessage(error: unknown) {
-  let message = ""
-  try {
-    message =
-      error instanceof TransactionError || error instanceof Error
-        ? error.message || error.toString()
-        : typeof error === "object"
-          ? JSON.stringify(error)
-          : `${error}`
-  } catch (err) {}
-
-  return message
-}
-
-function getErrorTemplate(data: TTxErrorData = {}) {
-  return Object.entries(data)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join("\n")
 }

--- a/src/sections/transaction/ReviewTransactionError.utils.tsx
+++ b/src/sections/transaction/ReviewTransactionError.utils.tsx
@@ -1,0 +1,35 @@
+import {
+  TransactionError,
+  TTxErrorData,
+} from "sections/transaction/ReviewTransaction.utils"
+
+type MetaMaskErrorObject = { data: { code: number; message: string } }
+
+function isMetaMaskErrorObject(error: unknown): error is MetaMaskErrorObject {
+  const data = (error as any)?.data
+  return typeof data?.code === "number" && typeof data?.message === "string"
+}
+
+export function parseErrorMessage(error: unknown) {
+  try {
+    switch (true) {
+      case isMetaMaskErrorObject(error):
+        return error.data.message
+      case typeof error === "object":
+        return JSON.stringify(error)
+      case error instanceof TransactionError:
+      case error instanceof Error:
+        return error.message
+      default:
+        return `${error}`
+    }
+  } catch {
+    return ""
+  }
+}
+
+export function getErrorTemplate(data: TTxErrorData = {}) {
+  return Object.entries(data)
+    .map(([key, value]) => `${key}: ${value}`)
+    .join("\n")
+}


### PR DESCRIPTION
Current: In Nova Wallet, if user changes connected account through Nova Wallet UI (not inside dApp browser), this change is not reflected in Hydration UI.

After fix: When user changes account in Nova Wallet, Hydration UI should automatically switch to this account.