### PR TITLE
f/HYDRA-1243 - OTC

### DIFF
--- a/apps/main/src/modules/trade/otc/fill-order/FillOrderModalContent.tsx
+++ b/apps/main/src/modules/trade/otc/fill-order/FillOrderModalContent.tsx
@@ -56,13 +56,13 @@ export const FillOrderModalContent: FC<Props> = ({
     onSubmit: onClose,
   })
 
-  const [sellAmount, buyAmount] = form.watch(["sellAmount", "buyAmount"])
+  const sellAmount = form.watch("sellAmount")
 
-  const feeAsset = otcOffer.assetOut
+  const feeAsset = otcOffer.assetIn
   const fee =
-    !buyAmount || !feePct
+    !sellAmount || !feePct
       ? undefined
-      : Big(buyAmount).div(Big(1).minus(feePct)).minus(buyAmount).toString()
+      : Big(sellAmount).times(feePct).toString()
 
   const [feeDisplay] = useDisplayAssetPrice(feeAsset.id, fee || "0")
 

--- a/apps/main/src/modules/trade/otc/place-order/PlaceOrderModalContent.utils.ts
+++ b/apps/main/src/modules/trade/otc/place-order/PlaceOrderModalContent.utils.ts
@@ -22,7 +22,7 @@ export const getPrice = (
       ? priceSettings.value || "0"
       : calculatePriceWithDiff(
           omnipoolPriceBig.toString(),
-          Big(priceSettings.percentage).times(-1).toString(),
+          Big(priceSettings.percentage).toString(),
         )
 
   const priceGain =
@@ -32,12 +32,10 @@ export const getPrice = (
         ? "0"
         : Big(
             math.calculateDiffToRef(
-              BigInt(scale(omnipoolPrice, priceDecimals)),
               BigInt(scale(price, priceDecimals)),
+              BigInt(scale(omnipoolPrice, priceDecimals)),
             ),
-          )
-            .times(-1)
-            .toString()
+          ).toString()
 
   return { price, priceGain }
 }
@@ -45,4 +43,5 @@ export const getPrice = (
 const calculatePriceWithDiff = (
   omnipoolPrice: string,
   percentage: string,
-): string => Big(omnipoolPrice).div(Big(percentage).div(100).plus(1)).toString()
+): string =>
+  Big(omnipoolPrice).times(Big(percentage).div(100).plus(1)).toString()

--- a/apps/main/src/modules/trade/otc/table/OtcTable.columns.tsx
+++ b/apps/main/src/modules/trade/otc/table/OtcTable.columns.tsx
@@ -27,7 +27,13 @@ import { FillOrderModalContent } from "@/modules/trade/otc/fill-order/FillOrderM
 import { OfferMarketPriceColumn } from "@/modules/trade/otc/table/columns/OfferMarketPriceColumn"
 import { OfferPriceColumn } from "@/modules/trade/otc/table/columns/OfferPriceColumn"
 import { OtcOffer } from "@/modules/trade/otc/table/OtcTable.query"
-import { logically, nullFirst, numerically, sortBy } from "@/utils/sort"
+import {
+  logically,
+  nullFirst,
+  nullLast,
+  numerically,
+  sortBy,
+} from "@/utils/sort"
 
 export enum OtcColumn {
   MarketPrice = "MarketPrice",
@@ -96,7 +102,7 @@ export const useOtcTableColums = () => {
         },
         sortingFn: sortBy({
           select: (row) => row.original.marketPricePercentage,
-          compare: nullFirst(numerically),
+          compare: nullLast(numerically),
         }),
         cell: ({ row }) => {
           return (

--- a/apps/main/src/modules/trade/otc/table/OtcTable.tsx
+++ b/apps/main/src/modules/trade/otc/table/OtcTable.tsx
@@ -85,7 +85,7 @@ export const OtcTable: FC<Props> = ({ searchPhrase }) => {
         data={offersWithPrices}
         columns={columns}
         isLoading={isTableLoading}
-        initialSorting={[{ id: OtcColumn.MarketPrice, desc: true }]}
+        initialSorting={[{ id: OtcColumn.MarketPrice, desc: false }]}
         emptyState={t("otc.noOrders")}
       />
     </TableContainer>

--- a/apps/main/src/modules/trade/otc/table/OtcTable.utils.ts
+++ b/apps/main/src/modules/trade/otc/table/OtcTable.utils.ts
@@ -18,17 +18,22 @@ export const mapOtcOffersToTableData =
     const priceIn = assetPrices[assetIn.id]
     const priceOut = assetPrices[assetOut.id]
 
-    const offerPrice = priceIn?.isValid
-      ? new Big(assetAmountIn).mul(priceIn.price).div(assetAmountOut).toString()
-      : null
+    const offerPrice =
+      priceIn?.isValid && Big(priceIn.price).gt(0)
+        ? new Big(assetAmountIn)
+            .mul(priceIn.price)
+            .div(assetAmountOut)
+            .toString()
+        : null
 
     const marketPricePercentage =
       offerPrice &&
       typeof referenceAssetDecimals === "number" &&
-      priceOut?.isValid
+      priceOut?.isValid &&
+      Big(priceOut.price).gt(0)
         ? math.calculateDiffToRef(
-            BigInt(scale(priceOut.price, referenceAssetDecimals)),
             BigInt(scale(offerPrice, referenceAssetDecimals)),
+            BigInt(scale(priceOut.price, referenceAssetDecimals)),
           )
         : null
 

--- a/apps/main/src/modules/trade/otc/table/columns/OfferMarketPriceColumn.tsx
+++ b/apps/main/src/modules/trade/otc/table/columns/OfferMarketPriceColumn.tsx
@@ -17,14 +17,16 @@ export const OfferMarketPriceColumn: FC<Props> = ({ percentage }) => {
       fs={13}
       lh={1}
       color={
-        percentageNum > 0
+        percentageNum < 0
           ? getToken("details.values.positive")
-          : percentageNum < 0 && getToken("details.values.negative")
+          : percentageNum > 0 && getToken("details.values.negative")
       }
       truncate
     >
-      {percentageNum < 0 && "+"}
-      {t("percent", { value: percentage === null ? percentage : -percentage })}
+      {percentageNum > 0 && "+"}
+      {t("percent", {
+        value: percentage === null ? null : Math.abs(percentage),
+      })}
     </Text>
   )
 }

--- a/apps/main/src/utils/sort.ts
+++ b/apps/main/src/utils/sort.ts
@@ -56,6 +56,19 @@ export const nullFirst =
     return compare(a, b)
   }
 
+export const nullLast =
+  <T>(compare: Compare<T>): Compare<T | null> =>
+  (a, b) => {
+    if (a === null) {
+      return 1
+    }
+    if (b === null) {
+      return -1
+    }
+
+    return compare(a, b)
+  }
+
 export const naturally: Compare<string> = (a, b) => a.localeCompare(b)
 export const naturallyDesc = descending(naturally)
 


### PR DESCRIPTION
Fix market price diff calculation (old app had it reversed and wrong)
Show N/A market price for assets with price 0
When filling order show fee from the pay asset