### PR TITLE
f/HYDRA-1243 - OTC

### DIFF
--- a/apps/main/src/i18n/locales/en/trade.json
+++ b/apps/main/src/i18n/locales/en/trade.json
@@ -141,7 +141,7 @@
   "otc.placeOrder.lastOmniPoolPrice": "MARKET PRICE",
   "otc.placeOrder.validation.sameAssets": "Cannot place order for the same asset.",
   "otc.placeOrder.priceGainWarning.buy": "Buying {{ asset }} above market price. Your price is {{ percentage }} higher. Check out our Swap page or confirm that you want to continue anyway.",
-  "otc.placeOrder.priceGainWarning.sell": "Selling {{ asset }} below market price. Your price is {{ percentage }} lower. Check out our Swap page or confirm that you want to continue anyway.",
+  "otc.placeOrder.priceGainWarning.offer": "Selling {{ asset }} below market price. Your price is {{ percentage }} lower. Check out our Swap page or confirm that you want to continue anyway.",
   "otc.placeOrder.priceGainWarning.confirmation": "I understand and want to proceed regardless.",
   "otc.fillOrder.tradeFee": "Trade fee ({{ percentage }}%)",
   "otc.fillOrder.cta": "Fill order",

--- a/apps/main/src/modules/trade/otc/cancel-order/CancelOtcOrderModalContent.submit.ts
+++ b/apps/main/src/modules/trade/otc/cancel-order/CancelOtcOrderModalContent.submit.ts
@@ -7,7 +7,7 @@ import { useTransactionsStore } from "@/states/transactions"
 
 export const useSubmitCancelOtcOrder = (
   otcOffer: OtcOfferTabular,
-  onSubmit: () => void,
+  onSubmitted: () => void,
 ) => {
   const { t } = useTranslation(["trade", "common"])
   const { papi } = useRpcProvider()
@@ -25,21 +25,25 @@ export const useSubmitCancelOtcOrder = (
         symbol: otcOffer.assetOut.symbol,
       })
 
-      onSubmit()
-      await createTransaction({
-        tx,
-        toasts: {
-          submitted: t("otc.cancelOrder.loading", {
-            amount: formattedAmount,
-          }),
-          success: t("otc.cancelOrder.success", {
-            amount: formattedAmount,
-          }),
-          error: t("otc.cancelOrder.error", {
-            amount: formattedAmount,
-          }),
+      await createTransaction(
+        {
+          tx,
+          toasts: {
+            submitted: t("otc.cancelOrder.loading", {
+              amount: formattedAmount,
+            }),
+            success: t("otc.cancelOrder.success", {
+              amount: formattedAmount,
+            }),
+            error: t("otc.cancelOrder.error", {
+              amount: formattedAmount,
+            }),
+          },
         },
-      })
+        {
+          onSubmitted,
+        },
+      )
     },
   })
 }

--- a/apps/main/src/modules/trade/otc/fill-order/FillOrderModalContent.submit.ts
+++ b/apps/main/src/modules/trade/otc/fill-order/FillOrderModalContent.submit.ts
@@ -14,10 +14,10 @@ const FULL_ORDER_PCT_LBOUND = 99
 
 type Args = {
   readonly otcOffer: OtcOfferTabular
-  readonly onSubmit: () => void
+  readonly onSubmitted: () => void
 }
 
-export const useSubmitFillOrder = ({ otcOffer, onSubmit }: Args) => {
+export const useSubmitFillOrder = ({ otcOffer, onSubmitted }: Args) => {
   const { t } = useTranslation(["trade", "common"])
   const { papi } = useRpcProvider()
   const { isErc20AToken } = useAssets()
@@ -51,26 +51,30 @@ export const useSubmitFillOrder = ({ otcOffer, onSubmit }: Args) => {
               order_id: Number(otcOffer.id),
             })
 
-      onSubmit()
-      await createTransaction({
-        tx: hasAToken
-          ? papi.tx.Dispatcher.dispatch_with_extra_gas({
-              call: tx.decodedCall,
-              extra_gas: AAVE_GAS_LIMIT,
-            })
-          : tx,
-        toasts: {
-          submitted: t("otc.fillOrder.loading", {
-            amount: formattedAmount,
-          }),
-          success: t("otc.fillOrder.success", {
-            amount: formattedAmount,
-          }),
-          error: t("otc.fillOrder.error", {
-            amount: formattedAmount,
-          }),
+      await createTransaction(
+        {
+          tx: hasAToken
+            ? papi.tx.Dispatcher.dispatch_with_extra_gas({
+                call: tx.decodedCall,
+                extra_gas: AAVE_GAS_LIMIT,
+              })
+            : tx,
+          toasts: {
+            submitted: t("otc.fillOrder.loading", {
+              amount: formattedAmount,
+            }),
+            success: t("otc.fillOrder.success", {
+              amount: formattedAmount,
+            }),
+            error: t("otc.fillOrder.error", {
+              amount: formattedAmount,
+            }),
+          },
         },
-      })
+        {
+          onSubmitted,
+        },
+      )
     },
   })
 }

--- a/apps/main/src/modules/trade/otc/fill-order/FillOrderModalContent.tsx
+++ b/apps/main/src/modules/trade/otc/fill-order/FillOrderModalContent.tsx
@@ -53,7 +53,7 @@ export const FillOrderModalContent: FC<Props> = ({
   const form = useFillOrderForm(otcOffer, isUsersOffer, feePct)
   const submit = useSubmitFillOrder({
     otcOffer,
-    onSubmit: onClose,
+    onSubmitted: onClose,
   })
 
   const sellAmount = form.watch("sellAmount")
@@ -66,7 +66,8 @@ export const FillOrderModalContent: FC<Props> = ({
 
   const [feeDisplay] = useDisplayAssetPrice(feeAsset.id, fee || "0")
 
-  const isSubmitEnabled = isUsersOffer || form.formState.isValid
+  const isSubmitEnabled =
+    isUsersOffer || (!!sellAmount && form.formState.isValid)
 
   if (isSubmitCancelOpen) {
     return (

--- a/apps/main/src/modules/trade/otc/place-order/PlaceOrderModalContent.form.ts
+++ b/apps/main/src/modules/trade/otc/place-order/PlaceOrderModalContent.form.ts
@@ -18,6 +18,8 @@ import {
 
 export const marketPriceOptions = [-3, -1, 0, 3, 5, 10] as const
 
+const view = z.literal(["offerPrice", "buyPrice"])
+
 const useSchema = () => {
   const rpc = useRpcProvider()
   const { data: existentialDepositMultiplier } = useQuery(
@@ -39,9 +41,9 @@ const useSchema = () => {
         }),
         z.object({
           type: z.literal("fixed"),
-          value: required.pipe(positive),
-          inputValue: z.string(),
-          wasPriceSwitched: z.boolean(),
+          offerPrice: required.pipe(positive),
+          buyPrice: required.pipe(positive),
+          view,
         }),
       ]),
       priceConfirmation: z
@@ -49,7 +51,7 @@ const useSchema = () => {
           confirmed: z.boolean(),
         })
         .nullable(),
-      isPriceSwitched: z.boolean(),
+      view,
       isPartiallyFillable: z.boolean(),
     })
     .check(
@@ -80,6 +82,7 @@ const useSchema = () => {
 
 export type PlaceOrderFormValues = z.infer<ReturnType<typeof useSchema>>
 export type PriceSettings = PlaceOrderFormValues["priceSettings"]
+export type PlaceOrderView = PlaceOrderFormValues["view"]
 
 export const usePlaceOrderForm = () => {
   const defaultValues: PlaceOrderFormValues = {
@@ -92,7 +95,7 @@ export const usePlaceOrderForm = () => {
       percentage: 0,
     },
     priceConfirmation: null,
-    isPriceSwitched: false,
+    view: "offerPrice",
     isPartiallyFillable: true,
   }
 

--- a/apps/main/src/modules/trade/otc/place-order/PlaceOrderModalContent.submit.ts
+++ b/apps/main/src/modules/trade/otc/place-order/PlaceOrderModalContent.submit.ts
@@ -9,10 +9,10 @@ import { useTransactionsStore } from "@/states/transactions"
 import { scale } from "@/utils/formatting"
 
 type Args = {
-  readonly onSubmit: () => void
+  readonly onSubmitted: () => void
 }
 
-export const useSubmitPlaceOrder = ({ onSubmit }: Args) => {
+export const useSubmitPlaceOrder = ({ onSubmitted }: Args) => {
   const { t } = useTranslation(["trade", "common"])
   const { papi } = useRpcProvider()
   const { isErc20AToken } = useAssets()
@@ -46,26 +46,30 @@ export const useSubmitPlaceOrder = ({ onSubmit }: Args) => {
         partially_fillable: isPartiallyFillable,
       })
 
-      onSubmit()
-      await createTransaction({
-        tx: hasAToken
-          ? papi.tx.Dispatcher.dispatch_with_extra_gas({
-              call: tx.decodedCall,
-              extra_gas: AAVE_GAS_LIMIT,
-            })
-          : tx,
-        toasts: {
-          submitted: t("otc.placeOrder.loading", {
-            amount: formattedAmount,
-          }),
-          success: t("otc.placeOrder.success", {
-            amount: formattedAmount,
-          }),
-          error: t("otc.placeOrder.error", {
-            amount: formattedAmount,
-          }),
+      await createTransaction(
+        {
+          tx: hasAToken
+            ? papi.tx.Dispatcher.dispatch_with_extra_gas({
+                call: tx.decodedCall,
+                extra_gas: AAVE_GAS_LIMIT,
+              })
+            : tx,
+          toasts: {
+            submitted: t("otc.placeOrder.loading", {
+              amount: formattedAmount,
+            }),
+            success: t("otc.placeOrder.success", {
+              amount: formattedAmount,
+            }),
+            error: t("otc.placeOrder.error", {
+              amount: formattedAmount,
+            }),
+          },
         },
-      })
+        {
+          onSubmitted,
+        },
+      )
     },
   })
 }

--- a/apps/main/src/modules/trade/otc/place-order/PlaceOrderPrice.tsx
+++ b/apps/main/src/modules/trade/otc/place-order/PlaceOrderPrice.tsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from "@galacticcouncil/ui/components"
 import { getToken, px } from "@galacticcouncil/ui/utils"
+import { getReversePrice } from "@galacticcouncil/utils"
 import Big from "big.js"
 import { FC } from "react"
 import { useController, useFormContext } from "react-hook-form"
@@ -16,6 +17,7 @@ import { useTranslation } from "react-i18next"
 import {
   marketPriceOptions,
   PlaceOrderFormValues,
+  PlaceOrderView,
   PriceSettings,
 } from "@/modules/trade/otc/place-order/PlaceOrderModalContent.form"
 import { TAsset } from "@/providers/assetsProvider"
@@ -48,10 +50,12 @@ export const PlaceOrderPrice: FC<Props> = ({
     name: "priceSettings",
   })
 
-  const { field: isPriceSwitchedField } = useController({
+  const { field: viewField } = useController({
     control,
-    name: "isPriceSwitched",
+    name: "view",
   })
+
+  const isOfferView = viewField.value === "offerPrice"
 
   const optionsWithFlags = marketPriceOptions.map(
     (option) =>
@@ -81,9 +85,7 @@ export const PlaceOrderPrice: FC<Props> = ({
       <Flex justify="space-between" height={18} align="center">
         <Text fw={500} fs="p5" lh={px(14.4)} color={getToken("text.medium")}>
           {t("otc.placeOrder.priceFor1", {
-            symbol: isPriceSwitchedField.value
-              ? buyAsset.symbol
-              : offerAsset.symbol,
+            symbol: isOfferView ? offerAsset.symbol : buyAsset.symbol,
           })}
         </Text>
         {!isPriceLoaded ? (
@@ -97,9 +99,9 @@ export const PlaceOrderPrice: FC<Props> = ({
               const isCustom = isDefault && hasCustomOption
 
               const usedOption = isCustom ? priceGain : option
-              const shownOption = isPriceSwitchedField.value
-                ? Big(usedOption).times(-1).toString()
-                : usedOption
+              const shownOption = isOfferView
+                ? usedOption
+                : Big(usedOption).times(-1).toString()
 
               return (
                 <MicroButton
@@ -134,34 +136,39 @@ export const PlaceOrderPrice: FC<Props> = ({
         <Flex py={4} pl={4} gap={4} align="center">
           <ButtonIcon
             onClick={() =>
-              isPriceSwitchedField.onChange(!isPriceSwitchedField.value)
+              viewField.onChange(
+                (isOfferView
+                  ? "buyPrice"
+                  : "offerPrice") satisfies PlaceOrderView,
+              )
             }
           >
             <AssetIcon />
           </ButtonIcon>
           <Text fw={600} fs="p3" lh={px(14)} color={getToken("text.high")}>
-            {isPriceSwitchedField.value ? offerAsset.symbol : buyAsset.symbol}
+            {isOfferView ? buyAsset.symbol : offerAsset.symbol}
           </Text>
         </Flex>
         <NumberInput
           variant="embedded"
           value={price}
           allowNegative={false}
-          onValueChange={({ value }, { source }) => {
+          onValueChange={({ value: price }, { source }) => {
             if (source === "prop") {
               return
             }
 
-            const newValue =
-              isPriceSwitchedField.value && Big(value || "0").gt(0)
-                ? Big(1).div(value).toString()
-                : value
+            const reversePrice = getReversePrice(price)
+
+            const [offerPrice, buyPrice] = isOfferView
+              ? [price, reversePrice]
+              : [reversePrice, price]
 
             changePriceSettings({
               type: "fixed",
-              value: newValue,
-              inputValue: value,
-              wasPriceSwitched: isPriceSwitchedField.value,
+              offerPrice,
+              buyPrice,
+              view: viewField.value,
             })
           }}
           placeholder="0"

--- a/apps/main/src/modules/trade/otc/place-order/PriceGainWarning.tsx
+++ b/apps/main/src/modules/trade/otc/place-order/PriceGainWarning.tsx
@@ -1,24 +1,28 @@
 import { Alert, Checkbox, Flex, Label } from "@galacticcouncil/ui/components"
 import { getTokenPx } from "@galacticcouncil/ui/utils"
+import Big from "big.js"
 import { FC } from "react"
 import { useController, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 
-import { PlaceOrderFormValues } from "@/modules/trade/otc/place-order/PlaceOrderModalContent.form"
+import {
+  PlaceOrderFormValues,
+  PlaceOrderView,
+} from "@/modules/trade/otc/place-order/PlaceOrderModalContent.form"
 import { TAsset } from "@/providers/assetsProvider"
 
 type Props = {
   readonly offerAsset: TAsset
   readonly buyAsset: TAsset
   readonly priceGain: string
-  readonly isPriceSwitched: boolean
+  readonly view: PlaceOrderView
 }
 
 export const PriceGainWarning: FC<Props> = ({
   offerAsset,
   buyAsset,
   priceGain,
-  isPriceSwitched,
+  view,
 }) => {
   const { t } = useTranslation(["common", "trade"])
   const { control } = useFormContext<PlaceOrderFormValues>()
@@ -32,6 +36,8 @@ export const PriceGainWarning: FC<Props> = ({
     return
   }
 
+  const isOfferView = view === "offerPrice"
+
   return (
     <Flex
       pt={getTokenPx("scales.paddings.m")}
@@ -44,10 +50,10 @@ export const PriceGainWarning: FC<Props> = ({
       <Alert
         variant="error"
         description={t(
-          `trade:otc.placeOrder.priceGainWarning.${isPriceSwitched ? "buy" : "sell"}`,
+          `trade:otc.placeOrder.priceGainWarning.${isOfferView ? "offer" : "buy"}`,
           {
-            asset: isPriceSwitched ? buyAsset.symbol : offerAsset.symbol,
-            percentage: t("percent", { value: priceGain }),
+            asset: isOfferView ? offerAsset.symbol : buyAsset.symbol,
+            percentage: t("percent", { value: Big(priceGain).abs() }),
           },
         )}
       />

--- a/apps/main/src/modules/trade/otc/table/OtcTable.columns.tsx
+++ b/apps/main/src/modules/trade/otc/table/OtcTable.columns.tsx
@@ -38,9 +38,13 @@ import {
 export enum OtcColumn {
   MarketPrice = "MarketPrice",
   Price = "Price",
-  Status = "Status",
+  PartiallyFillable = "PartiallyFillable",
   Actions = "Actions",
 }
+
+export const otcColumnSortPriority: ReadonlyArray<OtcColumn> = [
+  OtcColumn.PartiallyFillable,
+]
 
 export type OtcOfferTabular = OtcOffer & {
   readonly offerPrice: string | null
@@ -148,7 +152,7 @@ export const useOtcTableColums = () => {
     })
 
     const partiallyFillable = columnHelper.accessor("isPartiallyFillable", {
-      id: OtcColumn.Status,
+      id: OtcColumn.PartiallyFillable,
       header: t("otc.partiallyFillable"),
       meta: {
         sx: { textAlign: "center" },

--- a/apps/main/src/modules/trade/otc/table/OtcTable.tsx
+++ b/apps/main/src/modules/trade/otc/table/OtcTable.tsx
@@ -2,6 +2,7 @@ import {
   DataTable,
   Paper,
   TableContainer,
+  usePriorityTableSort,
 } from "@galacticcouncil/ui/components"
 import { useHydraAccountAddress } from "@galacticcouncil/web3-connect"
 import { useSearch } from "@tanstack/react-router"
@@ -10,6 +11,7 @@ import { useTranslation } from "react-i18next"
 
 import {
   OtcColumn,
+  otcColumnSortPriority,
   useOtcTableColums,
 } from "@/modules/trade/otc/table/OtcTable.columns"
 import { useOtcOffers } from "@/modules/trade/otc/table/OtcTable.query"
@@ -27,6 +29,11 @@ type Props = {
 export const OtcTable: FC<Props> = ({ searchPhrase }) => {
   const { t } = useTranslation("trade")
   const { offers: offersType } = useSearch({ from: "/trade/otc" })
+
+  const [sortState, setSortState] = usePriorityTableSort(
+    otcColumnSortPriority,
+    [{ id: OtcColumn.MarketPrice, desc: false }],
+  )
 
   const { getAsset } = useAssets()
   const { data, isLoading } = useOtcOffers()
@@ -85,8 +92,10 @@ export const OtcTable: FC<Props> = ({ searchPhrase }) => {
         data={offersWithPrices}
         columns={columns}
         isLoading={isTableLoading}
-        initialSorting={[{ id: OtcColumn.MarketPrice, desc: false }]}
         emptyState={t("otc.noOrders")}
+        isMultiSort
+        sorting={sortState}
+        onSortingChange={setSortState}
       />
     </TableContainer>
   )

--- a/apps/main/src/modules/trade/otc/table/columns/OfferMarketPriceColumn.tsx
+++ b/apps/main/src/modules/trade/otc/table/columns/OfferMarketPriceColumn.tsx
@@ -23,6 +23,7 @@ export const OfferMarketPriceColumn: FC<Props> = ({ percentage }) => {
       }
       truncate
     >
+      {percentageNum < 0 && "-"}
       {percentageNum > 0 && "+"}
       {t("percent", {
         value: percentage === null ? null : Math.abs(percentage),

--- a/packages/ui/src/components/DataTable/DataTable.tsx
+++ b/packages/ui/src/components/DataTable/DataTable.tsx
@@ -67,6 +67,7 @@ export type DataTableProps<TData extends RowData> = TableProps &
     globalFilterFn?: FilterFnOption<TData>
     multiExpandable?: boolean
     rowCount?: number
+    isMultiSort?: boolean
     getIsExpandable?: (item: TData) => boolean
     renderSubComponent?: (item: TData) => React.ReactElement
     renderOverride?: (item: TData) => React.ReactElement | undefined
@@ -103,6 +104,7 @@ const DataTable = <TData,>({
   emptyState,
   columnPinning,
   rowCount,
+  isMultiSort,
   getIsExpandable,
   renderSubComponent,
   renderOverride,
@@ -131,6 +133,7 @@ const DataTable = <TData,>({
     manualSorting,
     enableSortingRemoval,
     globalFilterFn: globalFilterFn ?? "auto",
+    ...(isMultiSort && { isMultiSortEvent: () => true }),
     ...(rowCount !== undefined && {
       rowCount,
       manualPagination: true,

--- a/packages/utils/src/helpers/math.ts
+++ b/packages/utils/src/helpers/math.ts
@@ -17,3 +17,6 @@ export const percentageDifference = (
 
   return aBig.minus(bBig).abs().div(aBig.plus(bBig).div(2)).mul(100)
 }
+
+export const getReversePrice = (price: string): string =>
+  Big(price || "0").gt(0) ? Big(1).div(price).toString() : price


### PR DESCRIPTION
Fix recalculations - offer price and buy price (reverse view) is held every time user sets the price and every field that is calculated will use the appropriate one for calculation based on current view so there is least number of calculations before getting a result. All of this because when dividing we will most likely lose precision due to repeating decimals.

Multisort as requested by Ondrej. Also forcing PartiallyFillable column to always have priority if it is toggled on. Meaning table will be first sort by the flag and then by the market price diff. Different order does not make sense for this table as basically all prices are going to differ by some margin so secondary sort would not have any effect.