### PR TITLE
f/HYDRA-1286 - Dry run debug

### DIFF
--- a/apps/main/src/api/dryRun.ts
+++ b/apps/main/src/api/dryRun.ts
@@ -1,36 +1,57 @@
-import { DryRunErrorDecoder } from "@galacticcouncil/utils"
+import { QUERY_KEY_BLOCK_PREFIX } from "@galacticcouncil/utils"
+import { queryOptions } from "@tanstack/react-query"
 
 import { decodeTx } from "@/modules/transactions/review/ReviewTransactionJsonView/ReviewTransactionJsonView.utils"
 import { AnyPapiTx } from "@/modules/transactions/types"
-import { Papi } from "@/providers/rpcProvider"
+import { getPapiTransactionCallData } from "@/modules/transactions/utils/tx"
+import { TProviderContext } from "@/providers/rpcProvider"
 
-export const getPapiDryRunError = async (
-  papi: Papi,
-  dryRunErrorDecoder: DryRunErrorDecoder,
+export const papiDryRunErrorQuery = (
+  { papi, dryRunErrorDecoder, papiCompatibilityToken }: TProviderContext,
   address: string,
   tx: AnyPapiTx,
-) => {
-  try {
-    const result = await papi.apis.DryRunApi.dry_run_call(
-      {
-        type: "system",
-        value: {
-          type: "Signed",
-          value: address,
-        },
-      },
-      // @ts-expect-error contains structured call data
-      decodeTx(tx),
-      1,
-    )
+  debug?: boolean,
+) =>
+  queryOptions({
+    queryKey: [
+      QUERY_KEY_BLOCK_PREFIX,
+      "dryRun",
+      "papi",
+      address,
+      getPapiTransactionCallData(tx, papiCompatibilityToken),
+    ],
+    queryFn: async () => {
+      try {
+        const json = decodeTx(tx)
+        const result = await papi.apis.DryRunApi.dry_run_call(
+          {
+            type: "system",
+            value: {
+              type: "Signed",
+              value: address,
+            },
+          },
+          // @ts-expect-error contains structured call data
+          json,
+          1,
+        )
 
-    return !result.success || result.value.execution_result.success
-      ? null
-      : await dryRunErrorDecoder.parseError(
+        if (!result.success || result.value.execution_result.success) {
+          return null
+        }
+
+        const error = await dryRunErrorDecoder.parseError(
           result.value.execution_result.value.error,
         )
-  } catch (error) {
-    console.error(error)
-    return null
-  }
-}
+
+        if (debug && error) {
+          console.log(new Date().toLocaleTimeString(), error.name, json)
+        }
+
+        return error
+      } catch (error) {
+        console.error(error)
+        return null
+      }
+    },
+  })


### PR DESCRIPTION
React hook form becomes valid for a brief time period when flipping assets. Even if the after the flip its revalidated and there is a form error. So there is a dry run error for this state already. Now user clicks on max amount and since form is valid again it shown an error that was previously hidden. After a small debounce the transaction is recalculated and error is gone.

RHF is very buggy when it comes to recalculating validated inputs and following revalidation.

Added at least extra caching and logs for persisting dry run errors.