### PR TITLE
Fix xcm max button

### DIFF
--- a/apps/main/src/api/xcm.ts
+++ b/apps/main/src/api/xcm.ts
@@ -15,6 +15,7 @@ import { secondsToMilliseconds } from "date-fns"
 import { useEffect, useRef, useState } from "react"
 
 import { TProviderContext, useRpcProvider } from "@/providers/rpcProvider"
+import { toDecimal } from "@/utils/formatting"
 
 export const useCrossChainConfig = () => {
   const { sdk } = useRpcProvider()
@@ -179,12 +180,29 @@ export const xcmTransferQuery = (
         ? destAsset
         : undefined
 
-      return builder.build({
+      const transfer = await builder.build({
         srcAddress,
         dstAddress: destAddress,
         dstAsset: validDstAsset,
         tag: bridgeTag,
       })
+
+      const { balance, fee, max } = transfer.source
+      if (balance.isSame(fee) && max.amount > 0n) {
+        try {
+          const atMaxFee = await transfer.estimateFee(
+            toDecimal(max.amount, max.decimals),
+          )
+          const delta = atMaxFee.amount - fee.amount
+          if (delta > 0n) {
+            transfer.source.max = max.copyWith({ amount: max.amount - delta })
+          }
+        } catch {
+          // keep original max if re-pricing fails
+        }
+      }
+
+      return transfer
     },
     enabled:
       !!srcAddress &&


### PR DESCRIPTION
When a cross-chain transfer's fee is charged in the same asset being transferred, the SDK's max is based on the fee at the current amount. On routes where the fee scales with the amount, sending the full max can underfund the fee and fail. This re-estimates the fee at max and reduces max by the difference.

Gated by balance.isSame(fee), so it only affects same-asset (self-paying) fee transfers; all other transfers are unchanged. Falls back to the original max if re-pricing fails.