### PR TITLE
config: add Rotko SEA RPC, drop defunct IBP

### DIFF
--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -55,8 +55,8 @@ export const SQUID_URLS: IndexerProps[] = SQUID_URLS_CONFIG.map((config) => ({
 export const PROVIDERS: ProviderProps[] = [
   createProvider("Dwellir", "wss://hydration-rpc.n.dwellir.com"),
   createProvider("Dotters", "wss://hydration.dotters.network"),
-  createProvider("IBP", "wss://hydration.ibp.network"),
   createProvider("LATAM", "wss://hydration.rpc.stkd.io"),
+  createProvider("Rotko (SEA)", "wss://hydration.rotko.net"),
   createProvider("zipp", "wss://rpc.zipp.hydration.cloud"),
   createProvider("roach", "wss://rpc.roach.hydration.cloud"),
   createProvider("lait", "wss://rpc.lait.hydration.cloud"),


### PR DESCRIPTION
## Summary

- **Add** `wss://hydration.rotko.net` to the public RPC provider list — SEA-anchored endpoint operated by Rotko Networks (AS142108) on owned bare-metal in Bangkok with Hong Kong secondary, fronted by an anycast HAProxy cluster across 3 hosts.
- **Remove** `wss://hydration.ibp.network` — the IBP-branded hostname no longer resolves (NXDOMAIN), so users selecting it hit a hard failure. The Dotters cohort entry stays; Rotko continues participating as a backend behind Dotters.

## Why

No SEA-anchored independent provider currently appears in the dApp list:

| Provider | Region |
|---|---|
| Dwellir | Europe |
| ~~IBP~~ | DNS dead — this PR removes |
| Dotters | Multi-region cohort |
| LATAM (stkd.io) | LATAM |
| zipp / roach / lait / sin / coke | Galactic Council ops |

Adding an APAC anchor improves latency for SEA / East-Asia clients materially: typically **30–60ms RTT** from the new endpoint vs **250–350ms** for clients reaching EU/US endpoints.

## Verification

```bash
# IBP defunct
$ dig +short hydration.ibp.network
(empty — NXDOMAIN)

# Dotters still good (so the cohort entry stays)
$ curl -sX POST -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"system_chain","params":[]}' \
    https://hydration.dotters.network
{"jsonrpc":"2.0","id":1,"result":"Hydration"}

# Rotko endpoint live
$ curl -sX POST -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"system_chain","params":[]}' \
    https://hydration.rotko.net
{"jsonrpc":"2.0","id":1,"result":"Hydration"}

$ curl -sX POST -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"system_health","params":[]}' \
    https://hydration.rotko.net
{"result":{"peers":21,"isSyncing":false,"shouldHavePeers":true},...}
```

## Endpoint details

| | |
|---|---|
| URL | `wss://hydration.rotko.net` (also `https://hydration.rotko.net`) |
| Operator | Rotko Networks OÜ |
| ASN | [AS142108](https://www.peeringdb.com/net/36301) — peering at AMS-IX + BKNIX |
| Primary site | STT GDC Bangkok 1 |
| Secondary | HGC Hong Kong |
| Frontend | Anycast HAProxy cluster across 3 Bangkok hosts (BGP-announced) |
| Pruning | Archive |

## Operator background

Rotko Networks operates production RPC nodes across the Polkadot ecosystem (Polkadot, Kusama, AssetHub, multiple parachains) as part of the IBP cohort, with Hydration backend nodes currently participating in the IBP and Dotters load balancers. This PR adds a directly-branded entry so SEA users can pin to the regional endpoint explicitly without going through multi-region cohort load balancers.