### PR TITLE
add cross-chain swap price chart

### DIFF
--- a/apps/main/src/api/external/kraken.ts
+++ b/apps/main/src/api/external/kraken.ts
@@ -1,0 +1,109 @@
+import { queryOptions, useQuery } from "@tanstack/react-query"
+import z from "zod/v4"
+
+import { GC_TIME, STALE_TIME } from "@/utils/consts"
+
+const krakenCandleSchema = z.tuple([
+  z.number(), // [0] time (unix seconds)
+  z.string(), // [1] open
+  z.string(), // [2] high
+  z.string(), // [3] low
+  z.string(), // [4] close
+  z.string(), // [5] vwap
+  z.string(), // [6] volume
+  z.number(), // [7] count
+])
+
+const krakenOhlcResponseSchema = z.object({
+  error: z.array(z.string()),
+  result: z.record(
+    z.string(),
+    z.union([z.array(krakenCandleSchema), z.number()]),
+  ),
+})
+
+export type ForeignPricePoint = {
+  timestamp: number
+  close: number
+  open?: number
+  high?: number
+  low?: number
+}
+
+export type KrakenPricePoint = ForeignPricePoint &
+  Required<Pick<ForeignPricePoint, "open" | "high" | "low">>
+
+// Allowlisted cross-chain destination platforms -> Kraken USD pairs.
+// Keep this an explicit allowlist (mirrors the backend proxy proposal).
+export const KRAKEN_PAIRS = {
+  near: "NEARUSD",
+  zec: "ZECUSD",
+} as const
+
+export type KrakenPlatform = keyof typeof KRAKEN_PAIRS
+
+export const krakenPairForPlatform = (
+  platform: string | undefined,
+): string | undefined => KRAKEN_PAIRS[platform as KrakenPlatform]
+
+const KRAKEN_BASE = "https://api.kraken.com/0/public"
+
+const fetchKrakenOhlc = async (
+  pair: string,
+  interval: number,
+): Promise<KrakenPricePoint[]> => {
+  const res = await fetch(
+    `${KRAKEN_BASE}/OHLC?pair=${pair}&interval=${interval}`,
+  )
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch Kraken OHLC: ${res.statusText}`)
+  }
+
+  const json = await res.json()
+  const parsed = krakenOhlcResponseSchema.parse(json)
+
+  if (parsed.error.length) {
+    throw new Error(`Kraken error: ${parsed.error.join(", ")}`)
+  }
+
+  // Kraken may return the pair under a legacy key (e.g. XZECZUSD) rather than
+  // the requested name — grab the first candle array, ignoring the "last" cursor.
+  const candles = Object.entries(parsed.result).find(
+    ([key, value]) => key !== "last" && Array.isArray(value),
+  )?.[1]
+
+  if (!Array.isArray(candles)) {
+    return []
+  }
+
+  return candles.map((candle) => ({
+    timestamp: candle[0],
+    open: Number(candle[1]),
+    high: Number(candle[2]),
+    low: Number(candle[3]),
+    close: Number(candle[4]),
+  }))
+}
+
+export const krakenOhlcQuery = (pair: string, interval: number) =>
+  queryOptions({
+    queryKey: ["krakenOhlc", pair, interval],
+    queryFn: () => fetchKrakenOhlc(pair, interval),
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+    retry: 2,
+  })
+
+export const useKrakenOhlc = (
+  platform: string | undefined,
+  interval: number,
+  enabled = true,
+) => {
+  const pair = krakenPairForPlatform(platform)
+
+  return useQuery({
+    ...krakenOhlcQuery(pair ?? "", interval),
+    enabled: enabled && !!pair,
+  })
+}

--- a/apps/main/src/config/xcSwap.ts
+++ b/apps/main/src/config/xcSwap.ts
@@ -1,4 +1,5 @@
 import { HOLLAR_ASSET_ID, HYDRATION_CHAIN_KEY } from "@galacticcouncil/utils"
+import { WRAP_NEAR_ASSET, ZEC_ASSET } from "@galacticcouncil/xc-swap"
 
 import { NATIVE_ASSET_ID } from "@/utils/consts"
 
@@ -11,9 +12,17 @@ export const XC_SWAP_CHAIN_CMC_IDS = {
 } as const
 
 export const XC_SWAP_ASSET_CMC_IDS = {
-  "nep141:zec.omft.near": 1437,
-  "nep141:wrap.near": 6535,
+  [ZEC_ASSET]: 1437,
+  [WRAP_NEAR_ASSET]: 6535,
 } as const
+
+export const XC_SWAP_ASSET_META: Record<
+  string,
+  { name: string; symbol: string }
+> = {
+  [WRAP_NEAR_ASSET]: { name: "NEAR", symbol: "NEAR" },
+  [ZEC_ASSET]: { name: "Zcash", symbol: "ZEC" },
+}
 
 export const XC_SWAP_RECIPIENT_PLACEHOLDERS: Record<string, string> = {
   zec: "t1PKtYdJJHhc3Pxowmznkg7vdTwnhEsCvR4",

--- a/apps/main/src/modules/trade/orders/TradeOrdersHeader.tsx
+++ b/apps/main/src/modules/trade/orders/TradeOrdersHeader.tsx
@@ -34,7 +34,7 @@ type Props = {
 export const TradeOrdersHeader: FC<Props> = ({ paginationProps }) => {
   const { t } = useTranslation("trade")
   const { pathname } = useLocation()
-  const { tab, allPairs, assetIn, assetOut } = useSearch({
+  const { tab, allPairs, assetIn, assetOut, destPlatform } = useSearch({
     from: "/trade/_history",
   })
 
@@ -69,6 +69,7 @@ export const TradeOrdersHeader: FC<Props> = ({ paginationProps }) => {
             allPairs,
             assetIn,
             assetOut,
+            destPlatform,
           } satisfies TradeHistorySearchParams,
           resetScroll: false,
         }))}
@@ -99,7 +100,13 @@ export const TradeOrdersHeader: FC<Props> = ({ paginationProps }) => {
           onCheckedChange={(checked) => {
             navigate({
               to: ".",
-              search: { tab, allPairs: checked, assetIn, assetOut },
+              search: {
+                tab,
+                allPairs: checked,
+                assetIn,
+                assetOut,
+                destPlatform,
+              },
               resetScroll: false,
             })
           }}

--- a/apps/main/src/modules/trade/swap/SwapPageDesktop.tsx
+++ b/apps/main/src/modules/trade/swap/SwapPageDesktop.tsx
@@ -5,7 +5,7 @@ import { TwoColumnGrid } from "@/modules/layout/components/TwoColumnGrid/TwoColu
 import { TradeOrders } from "@/modules/trade/orders/TradeOrders"
 import { FormHeader } from "@/modules/trade/swap/components/FormHeader/FormHeader"
 import { PageHeader } from "@/modules/trade/swap/components/PageHeader/PageHeader"
-import { TradeChart } from "@/modules/trade/swap/components/TradeChart/TradeChart"
+import { SwapChart } from "@/modules/trade/swap/components/SwapChart/SwapChart"
 
 import { SSwapFormContainer } from "./SwapPage.styled"
 
@@ -16,7 +16,7 @@ export const SwapPageDesktop = () => {
     <Stack gap="xl">
       <PageHeader />
       <TwoColumnGrid template="sidebar">
-        <TradeChart height={TRADE_CHART_DESKTOP_HEIGHT} />
+        <SwapChart height={TRADE_CHART_DESKTOP_HEIGHT} />
         <SSwapFormContainer gridColumn={2} gridRow={[null, null, null, "1/-1"]}>
           <FormHeader />
           <Separator mx="-xl" />

--- a/apps/main/src/modules/trade/swap/SwapPageMobile.tsx
+++ b/apps/main/src/modules/trade/swap/SwapPageMobile.tsx
@@ -4,7 +4,7 @@ import { FC } from "react"
 
 import { TradeOrders } from "@/modules/trade/orders/TradeOrders"
 import { FormHeader } from "@/modules/trade/swap/components/FormHeader/FormHeader"
-import { TradeChart } from "@/modules/trade/swap/components/TradeChart/TradeChart"
+import { SwapChart } from "@/modules/trade/swap/components/SwapChart/SwapChart"
 
 import { SSwapFormContainer } from "./SwapPage.styled"
 
@@ -18,7 +18,7 @@ export const SwapPageMobile: FC = () => {
         <Separator mx={-20} />
         <Outlet />
       </SSwapFormContainer>
-      <TradeChart height={TRADE_CHART_MOBILE_HEIGHT} />
+      <SwapChart height={TRADE_CHART_MOBILE_HEIGHT} />
       <TradeOrders />
     </Flex>
   )

--- a/apps/main/src/modules/trade/swap/components/PageHeader/PageHeader.tsx
+++ b/apps/main/src/modules/trade/swap/components/PageHeader/PageHeader.tsx
@@ -1,11 +1,33 @@
+import { Flex, Stack, Text } from "@galacticcouncil/ui/components"
+import { getToken } from "@galacticcouncil/ui/utils"
+import { HYDRATION_CHAIN_KEY } from "@galacticcouncil/utils"
 import { useSearch } from "@tanstack/react-router"
 
 import { AssetHeader } from "@/components/AssetHeader"
+import { getXcSwapAssetLogoUrl, XC_SWAP_ASSET_META } from "@/config/xcSwap"
+import { XcLogo } from "@/modules/trade/swap/sections/XcSwap/components/ChainAssetSelect/XcLogo"
 import { useAssets } from "@/providers/assetsProvider"
 
 export const PageHeader = () => {
   const { getAsset } = useAssets()
-  const { assetOut } = useSearch({ from: "/trade/_history" })
+  const { assetOut, destPlatform } = useSearch({ from: "/trade/_history" })
+
+  const destMeta = XC_SWAP_ASSET_META[assetOut]
+  if (destPlatform !== HYDRATION_CHAIN_KEY && destMeta) {
+    return (
+      <Flex gap="base">
+        <XcLogo src={getXcSwapAssetLogoUrl(assetOut)} size="large" />
+        <Stack>
+          <Text fs="h7" lh={1} fw={600} font="primary">
+            {destMeta.name}
+          </Text>
+          <Text fs="p6" color={getToken("text.medium")}>
+            {destMeta.symbol}
+          </Text>
+        </Stack>
+      </Flex>
+    )
+  }
 
   const asset = getAsset(assetOut)
 

--- a/apps/main/src/modules/trade/swap/components/SwapChart/SwapChart.tsx
+++ b/apps/main/src/modules/trade/swap/components/SwapChart/SwapChart.tsx
@@ -1,0 +1,44 @@
+import { HYDRATION_CHAIN_KEY } from "@galacticcouncil/utils"
+import { useSearch } from "@tanstack/react-router"
+import React from "react"
+
+import { krakenPairForPlatform } from "@/api/external/kraken"
+import { XC_SWAP_ASSET_META } from "@/config/xcSwap"
+import { TradeChart } from "@/modules/trade/swap/components/TradeChart/TradeChart"
+import { XcSwapChart } from "@/modules/trade/swap/components/XcSwapChart/XcSwapChart"
+import { useAssets } from "@/providers/assetsProvider"
+
+type SwapChartProps = {
+  readonly height: number
+}
+
+export const SwapChart: React.FC<SwapChartProps> = ({ height }) => {
+  const { getAsset } = useAssets()
+  const { assetIn, assetOut, destPlatform } = useSearch({
+    from: "/trade/_history",
+  })
+
+  const sellAsset = getAsset(assetIn)
+  const destMeta = XC_SWAP_ASSET_META[assetOut]
+
+  const isCrossChain = destPlatform !== HYDRATION_CHAIN_KEY
+
+  if (
+    isCrossChain &&
+    krakenPairForPlatform(destPlatform) &&
+    destMeta &&
+    sellAsset
+  ) {
+    return (
+      <XcSwapChart
+        height={height}
+        sellAssetId={assetIn}
+        sellSymbol={sellAsset.symbol}
+        destPlatform={destPlatform}
+        destSymbol={destMeta.symbol}
+      />
+    )
+  }
+
+  return <TradeChart height={height} />
+}

--- a/apps/main/src/modules/trade/swap/components/XcSwapChart/XcSwapChart.data.ts
+++ b/apps/main/src/modules/trade/swap/components/XcSwapChart/XcSwapChart.data.ts
@@ -1,0 +1,144 @@
+import {
+  OhlcData,
+  toUTCTimestamp,
+} from "@galacticcouncil/ui/components/TradingViewChart/utils"
+import { USDT_ASSET_ID } from "@galacticcouncil/utils"
+import { useMemo } from "react"
+
+import { useKrakenOhlc } from "@/api/external/kraken"
+import { TIME_FRAME_MS } from "@/components/TimeFrame/TimeFrame.utils"
+import { TradeChartTimeFrameType } from "@/modules/trade/swap/components/TradeChart/TradeChart"
+import { useTradeChartData } from "@/modules/trade/swap/components/TradeChart/TradeChart.data"
+
+export type XcSwapChartTimeFrame = TradeChartTimeFrameType | "all"
+
+/**
+ * timeFrame -> Kraken interval (minutes). Chosen so the requested window stays
+ * within Kraken's 720-candle REST cap:
+ * hour  (1m)   -> 720m  = 12h   covers 1h
+ * day   (5m)   -> 3600m = 60h   covers 24h
+ * week  (60m)  -> 720h  = 30d   covers 7d
+ * month (240m) -> 2880h = 120d  covers 30d
+ * all   (1440m)-> 720d  ~ 2y
+ */
+const KRAKEN_INTERVALS: Record<XcSwapChartTimeFrame, number> = {
+  hour: 1,
+  day: 5,
+  week: 60,
+  month: 240,
+  all: 1440,
+}
+
+const hasOhlc = (
+  candle: Pick<OhlcData, "open" | "high" | "low">,
+): candle is Required<Pick<OhlcData, "open" | "high" | "low">> => {
+  return (
+    !!candle.open &&
+    candle.open > 0 &&
+    !!candle.high &&
+    candle.high > 0 &&
+    !!candle.low &&
+    candle.low > 0
+  )
+}
+
+type Args = {
+  readonly sellAssetId: string
+  readonly destPlatform: string
+  readonly timeFrame: XcSwapChartTimeFrame
+  readonly enabled?: boolean
+}
+
+/**
+ * Cross-rate price series for a cross-chain swap pair (Hydration asset X ->
+ * foreign asset Q on NEAR/ZEC), where we have no native pair data.
+ *
+ *   close = priceUSD(Q) / priceUSD(X)   // = X per Q (sell per buy)
+ *
+ * priceUSD(X) comes from our indexer (useTradeChartData), priceUSD(Q) from
+ * Kraken; USD is treated as USDT (asset 10). `close` is X-per-Q (value in the
+ * sell asset's units) to match the on-chain TradeChart: a chart labeled "X/Q"
+ * shows "how much X is 1 Q". The toggle inverts to "1 X = Q".
+ */
+export const useXcSwapChartData = ({
+  sellAssetId,
+  destPlatform,
+  timeFrame,
+  enabled = true,
+}: Args) => {
+  const {
+    prices: hydraPrices,
+    isLoading: isHydraLoading,
+    isError: isHydraError,
+    isSuccess: isHydraSuccess,
+  } = useTradeChartData({
+    assetInId: USDT_ASSET_ID,
+    assetOutId: sellAssetId,
+    timeFrame: timeFrame === "all" ? null : timeFrame,
+  })
+
+  const {
+    data: foreignPrices,
+    isLoading: isForeignLoading,
+    isError: isForeignError,
+    isSuccess: isForeignSuccess,
+  } = useKrakenOhlc(destPlatform, KRAKEN_INTERVALS[timeFrame], enabled)
+
+  const prices = useMemo<OhlcData[]>(() => {
+    if (!hydraPrices.length || !foreignPrices?.length) {
+      return []
+    }
+
+    const foreignSorted = [...foreignPrices].sort(
+      (a, b) => a.timestamp - b.timestamp,
+    )
+
+    const cutoffSec =
+      timeFrame === "all" ? 0 : (Date.now() - TIME_FRAME_MS[timeFrame]) / 1000
+
+    let hi = 0
+    let lastHydra = hydraPrices[0]?.close ?? 0
+    const result: OhlcData[] = []
+
+    for (const candle of foreignSorted) {
+      const tSec = candle.timestamp
+
+      while (hi < hydraPrices.length && Number(hydraPrices[hi]?.time) <= tSec) {
+        lastHydra = hydraPrices[hi]?.close ?? lastHydra
+        hi++
+      }
+
+      if (
+        tSec < cutoffSec ||
+        !lastHydra ||
+        lastHydra <= 0 ||
+        candle.close <= 0
+      ) {
+        continue
+      }
+
+      const point: OhlcData = {
+        time: toUTCTimestamp(tSec * 1000),
+
+        close: candle.close / lastHydra,
+      }
+
+      if (hasOhlc(candle)) {
+        point.open = candle.open / lastHydra
+        point.high = candle.high / lastHydra
+        point.low = candle.low / lastHydra
+      }
+
+      result.push(point)
+    }
+
+    return result
+  }, [hydraPrices, foreignPrices, timeFrame])
+
+  return {
+    prices,
+    isLoading: isHydraLoading || isForeignLoading,
+    isError: isHydraError || isForeignError,
+    isSuccess: isHydraSuccess && isForeignSuccess,
+  }
+}

--- a/apps/main/src/modules/trade/swap/components/XcSwapChart/XcSwapChart.tsx
+++ b/apps/main/src/modules/trade/swap/components/XcSwapChart/XcSwapChart.tsx
@@ -1,0 +1,310 @@
+import { timeFrameTypes } from "@galacticcouncil/main/src/components/TimeFrame/TimeFrame.utils"
+import {
+  ArrowLeftRight,
+  CandlestickChart,
+  LineChartIcon,
+} from "@galacticcouncil/ui/assets/icons"
+import {
+  Box,
+  ButtonIcon,
+  ChartValues,
+  Flex,
+  Icon,
+  Paper,
+  Separator,
+  TradingViewChart,
+  TradingViewChartRef,
+} from "@galacticcouncil/ui/components"
+import {
+  BaselineChartData,
+  OhlcData,
+} from "@galacticcouncil/ui/components/TradingViewChart/utils"
+import { getToken } from "@galacticcouncil/ui/utils"
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+import { last } from "remeda"
+
+import { useDisplayAssetPrice } from "@/components/AssetPrice"
+import { ChartState } from "@/components/ChartState"
+import {
+  ChartTimeRange,
+  ChartTimeRangeOptionType,
+} from "@/components/ChartTimeRange/ChartTimeRange"
+import i18n from "@/i18n"
+import { SChartInvertButton } from "@/modules/trade/swap/components/TradeChart/TradeChart.styled"
+import {
+  useXcSwapChartData,
+  XcSwapChartTimeFrame,
+} from "@/modules/trade/swap/components/XcSwapChart/XcSwapChart.data"
+
+type XcSwapChartType = "line" | "candles"
+
+const CHART_TYPE_OPTIONS: ReadonlyArray<{
+  key: XcSwapChartType
+  label: string
+  icon: React.ComponentType
+}> = [
+  { key: "line", label: "Line", icon: LineChartIcon },
+  { key: "candles", label: "Candles", icon: CandlestickChart },
+]
+
+const chartTimeFrameTypes = timeFrameTypes.filter((type) => type !== "minute")
+
+const intervalOptions = ([...chartTimeFrameTypes, "all"] as const).map<
+  ChartTimeRangeOptionType<XcSwapChartTimeFrame>
+>((option) => ({
+  key: option,
+  label: i18n.t(`chart.timeFrame.${option}`),
+}))
+
+const hasOhlc = (
+  point: OhlcData,
+): point is OhlcData & Required<Pick<OhlcData, "open" | "high" | "low">> => {
+  return (
+    !!point.open &&
+    point.open > 0 &&
+    !!point.high &&
+    point.high > 0 &&
+    !!point.low &&
+    point.low > 0
+  )
+}
+
+const isOhlcData = (
+  point: BaselineChartData | OhlcData | null,
+): point is OhlcData & Required<Pick<OhlcData, "open" | "high" | "low">> => {
+  return !!point && "close" in point && hasOhlc(point)
+}
+
+const invertChartPoint = (point: OhlcData): OhlcData => {
+  const close = point.close > 0 ? 1 / point.close : 0
+
+  if (!hasOhlc(point)) {
+    return { ...point, close }
+  }
+
+  return {
+    ...point,
+    open: 1 / point.open,
+    close,
+    high: 1 / point.low,
+    low: 1 / point.high,
+  }
+}
+
+type XcSwapChartProps = {
+  readonly height: number
+  // Hydration source asset (priced against USDT on the indexer).
+  readonly sellAssetId: string
+  readonly sellSymbol: string
+  // Cross-chain destination on Kraken: "near" | "zec".
+  readonly destPlatform: string
+  readonly destSymbol: string
+}
+
+export const XcSwapChart: React.FC<XcSwapChartProps> = ({
+  height,
+  sellAssetId,
+  sellSymbol,
+  destPlatform,
+  destSymbol,
+}) => {
+  const { t } = useTranslation()
+
+  const chartRef = useRef<TradingViewChartRef>(null)
+  const [isInverted, setIsInverted] = useState(false)
+  const [interval, setInterval] = useState<XcSwapChartTimeFrame>("week")
+  const [chartType, setChartType] = useState<XcSwapChartType>("line")
+  const [crosshair, setCrosshair] = useState<
+    BaselineChartData | OhlcData | null
+  >(null)
+
+  // close = sellAsset per buyAsset (X per Q), matching TradeChart's convention.
+  const { prices, isLoading, isSuccess, isError } = useXcSwapChartData({
+    sellAssetId,
+    destPlatform,
+    timeFrame: interval,
+  })
+
+  // Default close is X per Q ("1 buy = value sell", value in sell units, like
+  // the on-chain chart); invert toggles to Q per X.
+  const data = useMemo<OhlcData[]>(
+    () => (isInverted ? prices.map(invertChartPoint) : prices),
+    [prices, isInverted],
+  )
+
+  const hasCandleData = data.length > 0 && data.every(hasOhlc)
+  const selectedChartType =
+    chartType === "candles" && hasCandleData ? "candles" : "line"
+  const isEmpty = isSuccess && !data.length
+
+  useEffect(() => {
+    if (!hasCandleData && chartType === "candles") {
+      setChartType("line")
+    }
+  }, [chartType, hasCandleData])
+
+  // value is shown in `valueSymbol` and prices 1 `subjectSymbol`.
+  // Default: "1 buyAsset (Q) = value sellAsset (X)" — matches on-chain.
+  const valueSymbol = isInverted ? destSymbol : sellSymbol
+  const subjectSymbol = isInverted ? sellSymbol : destSymbol
+
+  const lastDataPoint = last(data)
+  const crosshairValue =
+    crosshair && "value" in crosshair ? crosshair.value : crosshair?.close
+  const value = crosshairValue ?? lastDataPoint?.close ?? 0
+  const candleCrosshair =
+    selectedChartType === "candles" && isOhlcData(crosshair) ? crosshair : null
+  const formattedCandleOhlc = candleCrosshair
+    ? [
+        `O: ${t("number", {
+          value: candleCrosshair.open,
+        })}`,
+        `H: ${t("number", {
+          value: candleCrosshair.high,
+        })}`,
+        `L: ${t("number", {
+          value: candleCrosshair.low,
+        })}`,
+        `C: ${t("number", {
+          value: candleCrosshair.close,
+        })}`,
+      ].join(" / ")
+    : null
+
+  // USD sub-line = USD value of 1 subject, always priced via the Hydration
+  // sell asset (the foreign asset has no on-chain price):
+  //   not inverted: value (sell-per-buy) × price(sell) = USD of 1 buy
+  //   inverted:     1 × price(sell)                    = USD of 1 sell
+  const usdValue = isInverted ? 1 : value
+  const [formattedAssetPrice, { isLoading: isAssetPriceLoading }] =
+    useDisplayAssetPrice(sellAssetId, usdValue, {
+      maximumFractionDigits: null,
+    })
+
+  // Render the value directly (no AnimatedValue tween): the value can jump
+  // across orders of magnitude on asset switch, and the tween would
+  // briefly show misleading intermediate numbers.
+  const chartValue =
+    !isEmpty && !isError
+      ? t("currency", { value, symbol: valueSymbol })
+      : undefined
+
+  const chartDisplayValue =
+    !isEmpty && !isError ? (
+      <Box position="relative">
+        <Box>
+          {t("price")}: {formattedAssetPrice}
+        </Box>
+        {formattedCandleOhlc && (
+          <Box
+            sx={{
+              position: "absolute",
+              top: "100%",
+              left: 0,
+              whiteSpace: "nowrap",
+            }}
+          >
+            {formattedCandleOhlc}
+          </Box>
+        )}
+      </Box>
+    ) : undefined
+
+  return (
+    <Paper p="xl">
+      <Flex align="flex-start" gap="base" justify="space-between">
+        <ChartValues
+          value={chartValue}
+          displayValue={chartDisplayValue}
+          isLoading={isLoading || isAssetPriceLoading}
+        />
+        <Flex align="center" gap="s" direction={["column", null, "row"]} wrap>
+          <SChartInvertButton
+            size="small"
+            variant="tertiary"
+            outline
+            onClick={() => setIsInverted((prev) => !prev)}
+          >
+            <Icon component={ArrowLeftRight} size="m" />
+            {subjectSymbol}/{valueSymbol}
+          </SChartInvertButton>
+          {hasCandleData && (
+            <>
+              <Separator
+                orientation="vertical"
+                mx="base"
+                sx={{
+                  height: "l",
+                  mt: "xs",
+                  display: ["none", null, null, null, "block"],
+                }}
+              />
+              {CHART_TYPE_OPTIONS.map((opt) => (
+                <ButtonIcon
+                  key={opt.key}
+                  size="small"
+                  outline={selectedChartType !== opt.key}
+                  onClick={() => setChartType(opt.key)}
+                >
+                  <Icon
+                    component={opt.icon}
+                    color={
+                      chartType === opt.key
+                        ? getToken("text.tint.quart")
+                        : "onContainer"
+                    }
+                    size="m"
+                  />
+                </ButtonIcon>
+              ))}
+            </>
+          )}
+          <Separator
+            orientation="vertical"
+            mx="base"
+            sx={{
+              height: "l",
+              mt: "xs",
+              display: ["none", null, null, null, "block"],
+            }}
+          />
+          <ChartTimeRange
+            sx={{ ml: "auto" }}
+            options={intervalOptions}
+            selectedOption={interval}
+            onSelect={(option) => {
+              setInterval(option.key)
+              chartRef.current?.resetZoom()
+            }}
+          />
+        </Flex>
+      </Flex>
+      <ChartState
+        sx={{ height }}
+        isError={isError}
+        isLoading={isLoading}
+        isEmpty={isEmpty}
+      >
+        {selectedChartType === "candles" ? (
+          <TradingViewChart
+            ref={chartRef}
+            type="Candlestick"
+            height={height}
+            data={data}
+            hidePriceIndicator
+            onCrosshairMove={setCrosshair}
+          />
+        ) : (
+          <TradingViewChart
+            ref={chartRef}
+            height={height}
+            data={data}
+            hidePriceIndicator
+            onCrosshairMove={setCrosshair}
+          />
+        )}
+      </ChartState>
+    </Paper>
+  )
+}

--- a/apps/main/src/modules/trade/swap/sections/XcSwap/XcSwapFields.tsx
+++ b/apps/main/src/modules/trade/swap/sections/XcSwap/XcSwapFields.tsx
@@ -7,6 +7,7 @@ import {
 } from "@galacticcouncil/ui/components"
 import { getToken } from "@galacticcouncil/ui/utils"
 import { AddressBookModal, WalletMode } from "@galacticcouncil/web3-connect"
+import type { XcSwapPlatform } from "@galacticcouncil/xc-swap"
 import { useNavigate } from "@tanstack/react-router"
 import { useCallback, useState } from "react"
 import { useFormContext } from "react-hook-form"
@@ -27,7 +28,7 @@ import { useSwitchXcAssets } from "@/modules/trade/swap/sections/XcSwap/hooks/us
 import { XcSwapFormValues } from "@/modules/trade/swap/sections/XcSwap/hooks/useXcSwapForm"
 import { useXcSwapFormReset } from "@/modules/trade/swap/sections/XcSwap/hooks/useXcSwapFormReset"
 import {
-  getXcSwapBuyAssetOutId,
+  getXcAssetId,
   isSameXcAsset,
 } from "@/modules/trade/swap/sections/XcSwap/lib/xcSwapAssets"
 import { useXcSwap } from "@/modules/trade/swap/sections/XcSwap/XcSwapProvider"
@@ -92,7 +93,7 @@ export const XcSwapFields: React.FC<Props> = ({ destChainAssetPairs }) => {
         search: (search) => ({
           ...search,
           assetIn: sellAsset.id,
-          assetOut: getXcSwapBuyAssetOutId(buyAsset) ?? search.assetOut,
+          assetOut: getXcAssetId(buyAsset) ?? search.assetOut,
         }),
         resetScroll: false,
       })
@@ -127,19 +128,16 @@ export const XcSwapFields: React.FC<Props> = ({ destChainAssetPairs }) => {
         resetForm()
       }
 
-      const assetOut = getXcSwapBuyAssetOutId(selection.asset)
-
-      if (assetOut) {
-        navigate({
-          to: ".",
-          search: (search) => ({
-            ...search,
-            assetIn: sellAsset?.id,
-            assetOut,
-          }),
-          resetScroll: false,
-        })
-      }
+      navigate({
+        to: ".",
+        search: (search) => ({
+          ...search,
+          assetIn: sellAsset?.id,
+          assetOut: getXcAssetId(selection.asset) ?? search.assetOut,
+          destPlatform: selection.chain.platform as XcSwapPlatform,
+        }),
+        resetScroll: false,
+      })
     },
     [getValues, navigate, resetForm, setValue, switchAssets],
   )

--- a/apps/main/src/modules/trade/swap/sections/XcSwap/XcSwapProvider.tsx
+++ b/apps/main/src/modules/trade/swap/sections/XcSwap/XcSwapProvider.tsx
@@ -2,6 +2,7 @@ import { HealthFactorResult } from "@galacticcouncil/money-market/utils"
 import { isH160Address } from "@galacticcouncil/utils"
 import { useAccount } from "@galacticcouncil/web3-connect"
 import { XcSwapClient } from "@galacticcouncil/xc-swap"
+import { useSearch } from "@tanstack/react-router"
 import { createContext, useContext } from "react"
 import { FormProvider } from "react-hook-form"
 
@@ -83,6 +84,7 @@ export const XcSwapProvider: React.FC<XcSwapProviderProps> = ({
   const { account } = useAccount()
   const rpc = useRpcProvider()
   const form = useXcSwapForm()
+  const { destPlatform } = useSearch({ from: "/trade/_history" })
   const {
     swap: {
       single: { swapSlippage },
@@ -107,6 +109,7 @@ export const XcSwapProvider: React.FC<XcSwapProviderProps> = ({
     destChainAssetPairs,
     assetIn,
     assetOut,
+    destPlatform,
     isOriginLoading,
     isDestLoading,
   })

--- a/apps/main/src/modules/trade/swap/sections/XcSwap/hooks/useSwitchXcAssets.ts
+++ b/apps/main/src/modules/trade/swap/sections/XcSwap/hooks/useSwitchXcAssets.ts
@@ -1,10 +1,11 @@
+import { HYDRATION_CHAIN_KEY } from "@galacticcouncil/utils"
 import { useNavigate } from "@tanstack/react-router"
 import { useCallback } from "react"
 import { useFormContext } from "react-hook-form"
 
 import { XcAsset } from "@/modules/trade/swap/sections/XcSwap/data/mock"
 import { XcSwapFormValues } from "@/modules/trade/swap/sections/XcSwap/hooks/useXcSwapForm"
-import { getXcSwapBuyAssetOutId } from "@/modules/trade/swap/sections/XcSwap/lib/xcSwapAssets"
+import { getXcAssetId } from "@/modules/trade/swap/sections/XcSwap/lib/xcSwapAssets"
 import { useXcSwap } from "@/modules/trade/swap/sections/XcSwap/XcSwapProvider"
 import { useAssets } from "@/providers/assetsProvider"
 
@@ -48,7 +49,8 @@ export const useSwitchXcAssets = () => {
       search: (search) => ({
         ...search,
         assetIn: newSellAsset?.id,
-        assetOut: getXcSwapBuyAssetOutId(newBuyAsset) ?? search.assetOut,
+        assetOut: getXcAssetId(newBuyAsset) ?? search.assetOut,
+        destPlatform: HYDRATION_CHAIN_KEY,
       }),
       resetScroll: false,
     })

--- a/apps/main/src/modules/trade/swap/sections/XcSwap/hooks/useXcSwapQuote.ts
+++ b/apps/main/src/modules/trade/swap/sections/XcSwap/hooks/useXcSwapQuote.ts
@@ -51,14 +51,25 @@ export const useXcSwapQuote = ({
 }: UseXcSwapQuoteParams) => {
   const { isApiLoaded } = rpc
 
-  const sellAsset = form.watch("sellAsset")
-  const buyAsset = form.watch("buyAsset")
-  const destChain = form.watch("destChain")
-  const isSingleTrade = form.watch("isSingleTrade")
-  const type = form.watch("type")
-  const sellAmount = form.watch("sellAmount")
-  const buyAmount = form.watch("buyAmount")
-  const destAddress = form.watch("destAddress")
+  const [
+    sellAsset,
+    buyAsset,
+    destChain,
+    isSingleTrade,
+    type,
+    sellAmount,
+    buyAmount,
+    destAddress,
+  ] = form.watch([
+    "sellAsset",
+    "buyAsset",
+    "destChain",
+    "isSingleTrade",
+    "type",
+    "sellAmount",
+    "buyAmount",
+    "destAddress",
+  ])
 
   const recipientPlaceholder = destChain
     ? XC_SWAP_RECIPIENT_PLACEHOLDERS[destChain.key]

--- a/apps/main/src/modules/trade/swap/sections/XcSwap/hooks/useXcSwapSelection.ts
+++ b/apps/main/src/modules/trade/swap/sections/XcSwap/hooks/useXcSwapSelection.ts
@@ -1,3 +1,4 @@
+import { XcSwapPlatform } from "@galacticcouncil/xc-swap"
 import { useEffect } from "react"
 import { UseFormReturn } from "react-hook-form"
 
@@ -7,6 +8,7 @@ import { XcSwapFormValues } from "@/modules/trade/swap/sections/XcSwap/hooks/use
 import {
   findXcChainAssetPair,
   getDefaultChainAssetPair,
+  getNormalizedXcAssetId,
 } from "@/modules/trade/swap/sections/XcSwap/lib/xcSwapAssets"
 import { useAssets } from "@/providers/assetsProvider"
 
@@ -16,6 +18,7 @@ type UseXcSwapSelectionParams = {
   destChainAssetPairs: XcChainAssetPair[]
   assetIn: string
   assetOut: string
+  destPlatform: XcSwapPlatform
   isOriginLoading: boolean
   isDestLoading: boolean
 }
@@ -26,6 +29,7 @@ export const useXcSwapSelection = ({
   destChainAssetPairs,
   assetIn,
   assetOut,
+  destPlatform,
   isOriginLoading,
   isDestLoading,
 }: UseXcSwapSelectionParams) => {
@@ -63,6 +67,11 @@ export const useXcSwapSelection = ({
     if (!isSelectionDataReady) return
 
     const dest =
+      destChainAssetPairs.find(
+        (p) =>
+          p.chain.platform === destPlatform &&
+          getNormalizedXcAssetId(p.asset) === assetOut,
+      ) ??
       findXcChainAssetPair(destChainAssetPairs, assetOut) ??
       getDefaultChainAssetPair(
         destChainAssetPairs,
@@ -75,7 +84,7 @@ export const useXcSwapSelection = ({
       form.setValue("destChain", dest.chain)
       form.setValue("buyAsset", dest.asset)
     }
-  }, [isSelectionDataReady, destChainAssetPairs, form, assetOut])
+  }, [isSelectionDataReady, destChainAssetPairs, form, assetOut, destPlatform])
 
   const destChain = form.watch("destChain")
   const isCrossChain = destChain?.platform !== "hydration"

--- a/apps/main/src/modules/trade/swap/sections/XcSwap/lib/xcSwapAssets.ts
+++ b/apps/main/src/modules/trade/swap/sections/XcSwap/lib/xcSwapAssets.ts
@@ -39,16 +39,15 @@ export const getDefaultChainAssetPair = (
         asset.oneClickId === defaultSelection.assetId),
   )
 
-export const getXcSwapBuyAssetOutId = (
-  asset: XcAsset | null | undefined,
-): string | undefined =>
-  asset?.id !== undefined ? String(asset.id) : undefined
-
-export const getXcAssetKey = (asset: XcAsset): string =>
+export const getNormalizedXcAssetId = (asset: XcAsset): string =>
   asset.id !== undefined ? String(asset.id) : (asset.oneClickId ?? asset.key)
 
+export const getXcAssetId = (
+  asset: XcAsset | null | undefined,
+): string | undefined => (asset ? getNormalizedXcAssetId(asset) : undefined)
+
 export const isSameXcAsset = (a: XcAsset, b: XcAsset): boolean =>
-  getXcAssetKey(a) === getXcAssetKey(b)
+  getNormalizedXcAssetId(a) === getNormalizedXcAssetId(b)
 
 export const isXcDestAsset = (
   asset: TAssetData | XcAsset | null | undefined,

--- a/apps/main/src/routes/trade/_history/route.tsx
+++ b/apps/main/src/routes/trade/_history/route.tsx
@@ -1,4 +1,9 @@
-import { HOLLAR_ASSET_ID, SELL_ONLY_ASSETS } from "@galacticcouncil/utils"
+import {
+  HOLLAR_ASSET_ID,
+  HYDRATION_CHAIN_KEY,
+  SELL_ONLY_ASSETS,
+} from "@galacticcouncil/utils"
+import type { XcSwapPlatform } from "@galacticcouncil/xc-swap"
 import { createFileRoute } from "@tanstack/react-router"
 import * as z from "zod/v4"
 
@@ -7,6 +12,12 @@ import { NATIVE_ASSET_ID } from "@/utils/consts"
 
 export const DEFAULT_TRADE_ASSET_IN_ID = HOLLAR_ASSET_ID
 export const DEFAULT_TRADE_ASSET_OUT_ID = NATIVE_ASSET_ID
+
+const XC_SWAP_PLATFORMS = [
+  "hydration",
+  "near",
+  "zec",
+] as const satisfies readonly XcSwapPlatform[]
 
 const searchSchema = z
   .object({
@@ -19,6 +30,10 @@ const searchSchema = z
       .string()
       .default(DEFAULT_TRADE_ASSET_OUT_ID)
       .catch(DEFAULT_TRADE_ASSET_OUT_ID),
+    destPlatform: z
+      .enum(XC_SWAP_PLATFORMS)
+      .default(HYDRATION_CHAIN_KEY)
+      .catch(HYDRATION_CHAIN_KEY),
     allPairs: z.boolean().default(true),
     page: z.number().optional(),
   })


### PR DESCRIPTION
Render a price chart for cross-chain (xc-swap) pairs where there's no native on-chain pair. The foreign asset (NEAR/ZEC) is priced from an external feed (Kraken or DefiLlama) and crossed with the Hydration sell asset's indexer USD price to build the cross-rate, matching the on-chain TradeChart conventions (orientation, windowing, styling).

- SwapChart picks XcSwapChart vs on-chain TradeChart via a bridge store (selection lives in XcSwapProvider, chart renders outside it)
- PageHeader shows the cross-chain buy asset icon/name
- temporary Kraken/DefiLlama source toggle for comparison
- docs/proposals/kraken-ohlc-proxy.md: backend proxy proposal