### PR TITLE
experiment: route mainnet RPC through legacy-caching subway (do not merge)

### DIFF
--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -53,19 +53,18 @@ export const SQUID_URLS: IndexerProps[] = SQUID_URLS_CONFIG.map((config) => ({
 }))
 
 export const PROVIDERS: ProviderProps[] = [
-  createProvider("Dwellir", "wss://hydration-rpc.n.dwellir.com"),
-  //createProvider("Dotters", "wss://hydration.dotters.network"),
-  // createProvider("LATAM", "wss://hydration.rpc.stkd.io"),
-  createProvider("Rotko (SEA)", "wss://hydration.rotko.net"),
-  // createProvider("zipp", "wss://rpc.zipp.hydration.cloud"),
-  // createProvider("roach", "wss://rpc.roach.hydration.cloud"),
-  // createProvider("lait", "wss://rpc.lait.hydration.cloud"),
-  //createProvider("parm", "wss://rpc.parm.hydration.cloud"),
-  createProvider("sin", "wss://rpc.sin.hydration.cloud"),
-  createProvider("coke", "wss://rpc.coke.hydration.cloud"),
-  createProvider("kril", "wss://node-dir.kril.hydration.cloud"),
-  createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
-  // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
+  // EXPERIMENT (do not merge): route ALL mainnet traffic through a single
+  // legacy-caching subway endpoint to validate the subway-fronting proposal.
+  // subway advertises legacy state_* (no chainHead) so papi falls back to the
+  // cacheable legacy path; getReadProof is now cacheable too. Throwaway test
+  // endpoint on lark (galacticcouncil/subway:readproof-test, upstream Dwellir
+  // mainnet). createProvider keeps the mainnet indexer/squid defaults, so
+  // dataEnv stays "mainnet" and the squid still works. Original mainnet RPCs
+  // (Dwellir/Rotko/sin/coke/kril/sparrow) intentionally omitted for the test.
+  createProvider(
+    "Legacy subway (test)",
+    "wss://mainnetsub.lark.hydration.cloud",
+  ),
   createProvider(
     "Testnet",
     "wss://rpc.nice.hydration.cloud",


### PR DESCRIPTION
**Experimental — DO NOT MERGE.** Throwaway validation of the subway-fronting proposal: point the mainnet RPC list at a single legacy-caching subway endpoint and confirm the app works end-to-end.

- **What** → `apps/main/src/config/rpc.ts` mainnet `PROVIDERS` reduced to one entry, `wss://mainnetsub.lark.hydration.cloud` (a subway). subway advertises legacy `state_*` and **no** `chainHead_*`, so papi falls back to the cacheable legacy path; `state_getReadProof` is now cacheable too. `createProvider` keeps the mainnet indexer/squid defaults → `dataEnv` stays `mainnet`, squid unchanged. Testnet/Paseo entries untouched.
- **Why** → measured ~78% legacy cache hit rate on real ambient traffic, and with `getReadProof` (the heaviest legacy method) now cacheable the backend forward rate collapses ~99% under load → large backend cut from fronting RPCs with subway.
- **How to test** → load the app, open the manual RPC picker (or seed `localStorage.rpcUrl`), confirm WS connects to `mainnetsub.lark.hydration.cloud`, traffic is legacy `state_*` (no chainHead), and `/trade/swap` + `/wallet/assets` render real mainnet data.
- **Note** → `mainnetsub.lark.hydration.cloud` is a throwaway test subway on lark (image `galacticcouncil/subway:readproof-test`, upstream Dwellir mainnet). It will be torn down. Revert this commit before any real use.
