### PR TITLE
experiment: route mainnet RPC through wsmux (chainHead multiplexer) — do not merge

### DIFF
--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -53,19 +53,13 @@ export const SQUID_URLS: IndexerProps[] = SQUID_URLS_CONFIG.map((config) => ({
 }))
 
 export const PROVIDERS: ProviderProps[] = [
-  createProvider("Dwellir", "wss://hydration-rpc.n.dwellir.com"),
-  //createProvider("Dotters", "wss://hydration.dotters.network"),
-  // createProvider("LATAM", "wss://hydration.rpc.stkd.io"),
-  createProvider("Rotko (SEA)", "wss://hydration.rotko.net"),
-  // createProvider("zipp", "wss://rpc.zipp.hydration.cloud"),
-  // createProvider("roach", "wss://rpc.roach.hydration.cloud"),
-  // createProvider("lait", "wss://rpc.lait.hydration.cloud"),
-  //createProvider("parm", "wss://rpc.parm.hydration.cloud"),
-  createProvider("sin", "wss://rpc.sin.hydration.cloud"),
-  createProvider("coke", "wss://rpc.coke.hydration.cloud"),
-  createProvider("kril", "wss://node-dir.kril.hydration.cloud"),
-  createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
-  // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
+  // EXPERIMENT (do not merge): route mainnet RPC through wsmux, a chainHead
+  // multiplexer/cache. Single endpoint so the app keeps the chainHead_v1_*
+  // protocol end-to-end (no legacy state_* downgrade); fan-in + cross-client
+  // cache happen at the proxy. wsmux fans N client follows into ~N/4 upstream
+  // follows to the archive node. Throwaway lark infra; mainnet indexer/squid
+  // kept (defaults). See PR description.
+  createProvider("wsmux (chainHead, test)", "wss://wsmuxmain.lark.hydration.cloud"),
   createProvider(
     "Testnet",
     "wss://rpc.nice.hydration.cloud",


### PR DESCRIPTION
**Experimental — do not merge.** Routes mainnet RPC through a single `wsmux` endpoint to test chainHead-native shielding at the proxy. Throwaway lark infra.

- **What:** mainnet `PROVIDERS` → single `wsmux (chainHead, test)` at `wss://wsmuxmain.lark.hydration.cloud`. Mainnet indexer/squid unchanged.
- **Why:** wsmux is a chainHead multiplexer/cache → the app keeps the `chainHead_v1_*` protocol end-to-end (no legacy `state_*` downgrade), while fan-in + cross-client caching happen at the proxy. Contrast with the legacy-subway experiment (#3898) which downgraded the app to `state_*`.
- **Shielding (measured on lark):** N client follows fan into ~N/4 upstream `chainHead_v1_follow` subscriptions to the archive node. 200 concurrent raw chainHead clients → 101 upstream follows (~2:1), all 200 served, backend node CPU stayed in its idle noise band. `chainHead_v1_storage` reads served from the proxy cache (hits ≫ misses).
- **Endpoint verified:** `chainSpec_v1_chainName` = "Hydration", genesis matches the team archive node `hdx.tarn`, `rpc_methods` advertises `chainHead_v1_*` and **no** `system_chain`/legacy → chainHead-native.
- **Test notes:** image `galacticcouncil/wsmux:traefik-fix2`, upstream `wss://hdx.tarn.hydration.cloud`, `max_clients_per_connection: 8`, `chainHead_v1_follow.max_subscribers: 4`, preset `polkadot_v1`. Isolated lark stack `wsmuxmain`; tear down after evaluation.
