### PR TITLE
scope per-block invalidation to route + gate on tab visibility; debounce spot prices

### DIFF
--- a/apps/main/src/api/chain.ts
+++ b/apps/main/src/api/chain.ts
@@ -47,6 +47,20 @@ export const useBestNumber = () => {
   return useQuery(bestNumberQuery(useRpcProvider()))
 }
 
+// Block-tagged query domains (the second key segment after QUERY_KEY_BLOCK_PREFIX)
+// that are only relevant on a specific route. Off their route there is no observer
+// to render the data, so refetching them on every block is pure waste. They are
+// invalidated per block only while the matching route is mounted; everywhere else
+// they refetch lazily on next mount.
+const ROUTE_SCOPED_BLOCK_DOMAINS: Record<string, string> = {
+  trade: "/trade",
+  xcm: "/cross-chain",
+}
+
+// domains that are driven by their own cadence (spotPrice: 10s self-refresh via
+// spotPriceQuery; see api/spotPrice.ts) and must not be force-refetched every block.
+const SELF_REFRESHING_BLOCK_DOMAINS = new Set(["spotPrice"])
+
 export const useInvalidateOnBlock = () => {
   const queryClient = useQueryClient()
   const { papi, isApiLoaded } = useRpcProvider()
@@ -59,8 +73,36 @@ export const useInvalidateOnBlock = () => {
   useObservable(observable, {
     enabled: isApiLoaded,
     onUpdate: () => {
+      // skip the per-block refetch storm entirely while the tab is hidden;
+      // queries refetch on focus (refetchOnWindowFocus) when the user returns.
+      if (
+        typeof document !== "undefined" &&
+        document.visibilityState === "hidden"
+      ) {
+        return
+      }
+
+      const pathname =
+        typeof window !== "undefined" ? window.location.pathname : ""
+
       queryClient.invalidateQueries({
-        queryKey: [QUERY_KEY_BLOCK_PREFIX],
+        predicate: (query) => {
+          const [prefix, domain] = query.queryKey as [unknown, unknown]
+          if (prefix !== QUERY_KEY_BLOCK_PREFIX) return false
+
+          const domainKey = typeof domain === "string" ? domain : ""
+
+          // prices refresh on their own 10s cadence, never per block
+          if (SELF_REFRESHING_BLOCK_DOMAINS.has(domainKey)) return false
+
+          // route-scoped domains only refetch while on their route
+          const routePrefix = ROUTE_SCOPED_BLOCK_DOMAINS[domainKey]
+          if (routePrefix) return pathname.startsWith(routePrefix)
+
+          // everything else (bestNumber, tx-flow previews, wallet, etc.) stays
+          // fresh — these are either app-wide or gated by their own `enabled`.
+          return true
+        },
       })
     },
   })

--- a/apps/main/src/api/spotPrice.ts
+++ b/apps/main/src/api/spotPrice.ts
@@ -36,6 +36,11 @@ import { toDecimal } from "@/utils/formatting"
 import { TradeRouter } from "./trade"
 import { xykPoolWithLiquidityQuery } from "./xyk"
 
+// staleness budget for display spot prices (ms). prices refresh on this cadence
+// rather than on every block; ~10s matches the implicit budget of the existing
+// displayPrices subscriber.
+export const SPOT_PRICE_STALE_TIME = 10_000
+
 export const usePriceSubscriber = () => {
   const { isApiLoaded, sdk } = useRpcProvider()
   const queryClient = useQueryClient()
@@ -73,7 +78,7 @@ export const usePriceSubscriber = () => {
     },
     enabled: isApiLoaded && !isNullish(stableCoinId),
     notifyOnChangeProps: [],
-    staleTime: 10000,
+    staleTime: SPOT_PRICE_STALE_TIME,
   })
 }
 
@@ -92,6 +97,13 @@ export const spotPriceQuery = (
 
       return spotPrice
     },
+    // display spot prices do not need per-block freshness. useInvalidateOnBlock
+    // skips this domain; instead it self-refreshes on a ~10s cadence (matching the
+    // displayPrices subscriber budget), cutting router.getSpotPrice calls from
+    // once-per-asset-per-block (~6s) to once-per-asset-per-10s.
+    staleTime: SPOT_PRICE_STALE_TIME,
+    refetchInterval: SPOT_PRICE_STALE_TIME,
+    refetchIntervalInBackground: false,
   })
 }
 


### PR DESCRIPTION
Two related per-block RPC-efficiency fixes. U1's blanket per-block invalidation is what re-triggers the per-asset spot-price refetch (U2), so they ship together.

## Problem
- **U1** — `useInvalidateOnBlock()` (`api/chain.ts`), mounted globally in `__root.tsx`, runs `invalidateQueries([QUERY_KEY_BLOCK_PREFIX])` on **every block**, refetching every block-tagged query that is currently mounted — on every page, and even while the browser tab is hidden.
- **U2** — `spotPriceQuery` (`api/spotPrice.ts`, key `[BLOCK_PREFIX, "spotPrice", …]`) is consumed per displayed asset on trade/liquidity. Carrying the block prefix, it is force-refetched by U1 every block (~6 s), so `router.getSpotPrice` runs once per asset per block even though display prices only need ~10 s freshness.

## Fix
- `useInvalidateOnBlock` now:
  - **skips entirely while `document.visibilityState === "hidden"`** (queries refetch on focus via `refetchOnWindowFocus`), and
  - invalidates via a **`predicate`** instead of a blanket prefix match:
    - route-scoped domains (`trade` → `/trade`, `xcm` → `/cross-chain`) only refetch while their route is mounted;
    - `spotPrice` is exempted (it self-refreshes, below);
    - `bestNumber` and transaction-flow / app-wide domains stay fresh as before.
- `spotPriceQuery` gets `staleTime` + `refetchInterval` of 10 s (`SPOT_PRICE_STALE_TIME`) with `refetchIntervalInBackground: false`, so display prices refresh on a ~10 s cadence rather than per block. The existing `usePriceSubscriber` budget (was a magic `10000`) now reuses the same constant.

Conservative on purpose: `aave`/`healthFactor` block keys are NOT route-scoped because they are cross-route tx previews (wallet/liquidity/borrow) gated by their own `enabled`.

## Benchmark (labeled)
- **Functional smoke — MEASURED PASS.** Branch build served via `vite preview`, pinned to a mainnet RPC (Dwellir), driven headless. `/trade/swap` renders the live spot price (`1 HDX = 0.003856 HOLLAR`) and `$` values; `/wallet/assets?account=<treasury>` renders net worth `$12,134,732.02` + 38 `$` values. Prices populate within the staleness budget.
- **Per-block RPC reduction — PROJECTED (not cleanly measurable).** Full-app per-block capture is dominated by the SDK's own pool subscriptions (`chainHead_v1_storage`), which these UI changes do not touch and which vary **±70 % run-to-run** (same `/trade/swap`: 18.7 vs 32 frames/s across sessions). That noise swamps the app-layer delta, so a clean before→after number is not attributable from the WS stream. Projected effect against the measured baseline:
  - hidden tab: per-block app-layer invalidation refetches → **0** (gate short-circuits before `invalidateQueries`);
  - off-route `trade`/`xcm` block queries → **0** per-block refetches (were refetched whenever mounted across navigations);
  - `spotPrice`: `router.getSpotPrice` per displayed asset drops from **once / ~6 s block → once / 10 s** (~40 % fewer spot-price calls), and is no longer coupled to the block invalidation at all.

## Regression
typecheck (`tsc --noEmit`) ✅ · eslint ✅ · production build (`vite build && tsc`) ✅ · functional smoke ✅. No test runner exists in this repo (apps/main has no test script); the build's `tsc` pass + eslint are the gate.

## Staleness budget
Display prices ≤ ~10 s (matches the prior implicit `usePriceSubscriber` budget). `bestNumber` and active-route data stay per-block fresh. Hidden-tab data refreshes on focus.
