### PR TITLE
rpc: stop health-pinging when nobody's watching; no background polling

### DIFF
--- a/apps/main/src/api/rpc.ts
+++ b/apps/main/src/api/rpc.ts
@@ -10,7 +10,17 @@ import { useRef } from "react"
 import { PARACHAIN_BLOCK_TIME } from "@/utils/consts"
 import { pingWorker } from "@/workers/ping"
 
-export const rpcStatusQueryOptions = (url: string) =>
+type RpcStatusOptions = {
+  // keep the ~3s health ping running. defaults to false so the query only pings
+  // while actively observed (e.g. the provider modal is open). callers that show
+  // a live latency readout pass true.
+  poll?: boolean
+}
+
+export const rpcStatusQueryOptions = (
+  url: string,
+  { poll = false }: RpcStatusOptions = {},
+) =>
   queryOptions({
     enabled: !!url,
     queryKey: ["rpcStatus", url],
@@ -26,17 +36,21 @@ export const rpcStatusQueryOptions = (url: string) =>
       }
     },
     retry: 0,
-    refetchInterval: PARACHAIN_BLOCK_TIME / 2,
+    // only poll when asked, and never while the tab is hidden
+    refetchInterval: poll ? PARACHAIN_BLOCK_TIME / 2 : false,
     placeholderData: keepPreviousData,
-    refetchIntervalInBackground: true,
+    refetchIntervalInBackground: false,
   })
 
-export const useRpcStatus = (url: string) => {
-  return useQuery(rpcStatusQueryOptions(url))
+export const useRpcStatus = (url: string, options: RpcStatusOptions = {}) => {
+  return useQuery(rpcStatusQueryOptions(url, options))
 }
 
 type RpcsStatusOptions = {
   calculateAvgPing?: boolean
+  // see rpcStatusQueryOptions: defaults to false; the provider modal passes true
+  // so the latency list refreshes live while it is open.
+  poll?: boolean
 }
 
 export const useRpcsStatus = (
@@ -47,7 +61,7 @@ export const useRpcsStatus = (
 
   return useQueries({
     queries: urls.map((url, index) => ({
-      ...rpcStatusQueryOptions(url),
+      ...rpcStatusQueryOptions(url, { poll: options.poll }),
       queryFn: async () => {
         const delay = index * 150 // stagger queries for more accurate measurements
         if (delay > 0) await sleep(delay)

--- a/apps/main/src/components/DataProviderSelect/components/rpc/RpcList.tsx
+++ b/apps/main/src/components/DataProviderSelect/components/rpc/RpcList.tsx
@@ -45,6 +45,8 @@ export const RpcList: React.FC<RpcListProps> = ({ className }) => {
 
   const rpcsStatusQueries = useRpcsStatus(providerListUrls, {
     calculateAvgPing: true,
+    // modal is open while this list is mounted -> poll for a live latency readout
+    poll: true,
   })
 
   const handleSwitchRpc = (url: string) => {

--- a/apps/main/src/components/DataProviderSelect/components/rpc/RpcListItem.tsx
+++ b/apps/main/src/components/DataProviderSelect/components/rpc/RpcListItem.tsx
@@ -179,7 +179,11 @@ export const RpcListItemActive: React.FC<
 > = (props) => {
   const provider = useRpcProvider()
   const { data: bestNumber, isLoading } = useQuery(bestNumberQuery(provider))
-  const { data: status } = useRpcStatus(!props?.ping ? provider.endpoint : "")
+  const { data: status } = useRpcStatus(
+    !props?.ping ? provider.endpoint : "",
+    // active row inside the open provider modal -> poll for live latency
+    { poll: true },
+  )
 
   return (
     <RpcListItemLayout


### PR DESCRIPTION
## Problem
**U4** — `rpcStatusQueryOptions` (`api/rpc.ts`) sets `refetchInterval: PARACHAIN_BLOCK_TIME / 2` (~3 s) **and** `refetchIntervalInBackground: true`. Every consumer that mounts it (the provider/RPC list) health-pings each provider every ~3 s — and keeps pinging while the tab is hidden. With ~9 providers in the list that is a steady ~3 pings/s of `eth_getBlockByNumber` POSTs that continue in a backgrounded tab.

## Fix
- `rpcStatusQueryOptions(url, { poll = false })`: polling is now **opt-in**. Default `refetchInterval: false`; `refetchIntervalInBackground: false`.
- `useRpcStatus` / `useRpcsStatus` thread `poll` through.
- The two modal-only consumers (`RpcList`, `RpcListItem` active row) pass `poll: true`, so the live latency readout still updates while the provider modal is open. Everywhere else the query resolves once and then stays quiet.

Net: pings only fire while the provider modal is open **and** the tab is visible; closing the modal or backgrounding the tab stops them.

## Benchmark (labeled)
- **PROJECTED.** The ping is issued from a web worker (`pingWorker.getPing`) + `pingRpc`, so it does not surface on the main-page request hook and could not be counted reliably headless without scripted modal navigation. By construction:
  - baseline: ~`providers / 3 s` pings sustained whenever the modal is mounted, **including while the tab is hidden** (`refetchIntervalInBackground: true`);
  - branch: same rate only while modal-open **and** visible; **0** when the modal is closed or the tab is hidden.
- The ~3 s background ping is eliminated in exactly the conditions U4 calls out (modal closed / tab hidden).

## Regression
typecheck ✅ · eslint ✅ · production build ✅. No test runner in repo. Functional note: the modal latency list still polls (`poll: true`) so the live readout is unchanged while open; verified the only `useRpcStatus`/`useRpcsStatus` consumers are modal-scoped, so nothing outside the modal loses data.

## Staleness budget
Latency display updates every ~3 s while the modal is open and the tab is visible (unchanged UX). Hidden/closed → no polling, which is the intended behavior.
