### PR TITLE
borrow: give reserve reads a staleness budget; invalidate on the user's own tx

### DIFF
--- a/apps/main/src/api/borrow/queries.ts
+++ b/apps/main/src/api/borrow/queries.ts
@@ -46,6 +46,16 @@ import { TProviderContext, useRpcProvider } from "@/providers/rpcProvider"
 export const lendingPoolAddressProvider =
   AaveV3HydrationMainnet.POOL_ADDRESSES_PROVIDER
 
+// money-market reserve reads are ~5-8 eth_call per reserve. They carry no
+// staleTime, so any observer churn / mount refetches the full reserve set every
+// render, driving ~50-100 eth_call/block on the borrow dashboard. The underlying
+// data (rates, liquidity) moves at most once per block, so a one-block staleness
+// budget collapses the read fan-out while staying fresh; user-specific reserves
+// move only on the user's own tx, so they get a longer budget and are invalidated
+// explicitly on supply/borrow/repay/withdraw (see api/borrow/hooks tx flows).
+const RESERVES_STALE_TIME = 12_000
+const USER_RESERVES_STALE_TIME = 30_000
+
 export const borrowIncentivesQuery = (
   lendingPoolAddressProvider: string,
   incentivesContract: UiIncentiveDataProvider | null,
@@ -147,6 +157,7 @@ export const borrowReservesQuery = (
       }
     },
     retry: false,
+    staleTime: RESERVES_STALE_TIME,
     enabled:
       !!lendingPoolAddressProvider && !!poolDataContract && rpc.isApiLoaded,
   })
@@ -187,6 +198,7 @@ export const userBorrowReservesQuery = (
       })
     },
     retry: false,
+    staleTime: USER_RESERVES_STALE_TIME,
     enabled: !!evmAddress && !!lendingPoolAddressProvider && !!poolDataContract,
   })
 
@@ -409,6 +421,7 @@ export const userBorrowSummaryQuery = (
       return extendedUser
     },
     retry: false,
+    staleTime: USER_RESERVES_STALE_TIME,
     enabled: !!lendingPoolAddressProvider && !!evmAddress && rpc.isApiLoaded,
   })
 

--- a/apps/main/src/modules/borrow/BorrowContextProvider.tsx
+++ b/apps/main/src/modules/borrow/BorrowContextProvider.tsx
@@ -32,17 +32,23 @@ export const BorrowContextProvider: React.FC<PropsWithChildren> = ({
 
   const createTx = useCallback<MoneyMarketTxFn>(
     ({ tx, toasts }, options, withExtraGas) => {
+      // every money-market action (supply / borrow / repay / withdraw) mutates the
+      // user's reserves and the pool reserves. Reserve queries now hold a staleness
+      // budget (see api/borrow/queries.ts), so invalidate the whole borrow domain on
+      // tx success to refresh immediately rather than waiting out the budget.
+      const invalidateQueries = [["borrow"]]
       if (Array.isArray(tx)) {
         createBatchTx({
           txs: tx.map((evmTx) => transformEvmCallToPapiTx(papi, evmTx)),
           transaction: {
             toasts,
             withExtraGas,
+            invalidateQueries,
           },
           options,
         })
       } else {
-        createTransaction({ tx, toasts }, options)
+        createTransaction({ tx, toasts, invalidateQueries }, options)
       }
     },
     [createTransaction, createBatchTx, papi],


### PR DESCRIPTION
## Problem
**U3** — `borrowReservesQuery` / `userBorrowReservesQuery` / `userBorrowSummaryQuery` (`api/borrow/queries.ts`) wrap `getReservesHumanized` / `getUserReservesHumanized` (~5–8 `eth_call` per reserve) and carry **no `staleTime`** (default 0). Any observer churn or remount on the borrow dashboard refetches the full reserve set, driving a large `eth_call` / runtime-call fan-out per block. The underlying data moves at most once per block; user reserves move only on the user's own tx.

## Fix
- `borrowReservesQuery`: `staleTime: 12_000` (one block budget for pool reserves).
- `userBorrowReservesQuery` + `userBorrowSummaryQuery`: `staleTime: 30_000` (user reserves move only on the user's own action).
- `BorrowContextProvider.createTx` (the single chokepoint for every money-market supply/borrow/repay/withdraw) now attaches `invalidateQueries: [["borrow"]]`, so the user's own tx refreshes reserves immediately instead of waiting out the staleness budget.

## Benchmark (labeled)
- **PROJECTED.** Measured baseline on `/borrow/dashboard` (mainnet, treasury account): ~67 `chainHead_v1_call` + ~93 `chainHead_v1_storage` per block-change window; money-market reserve reads ride this `chainHead_v1_call` fan-out via the SDK. A clean before→after is not attributable because full-app per-block totals are dominated by SDK subscriptions and vary heavily run-to-run. Projected effect:
  - with `staleTime`, repeated reads inside a block window hit the cache instead of re-issuing the reserve `eth_call` set → reserve refetches drop from per-render/per-block to **at most once per 12 s** (reserves) / **once per 30 s** (user reserves);
  - against the investigation's ~50–100 eth_call/block reserve estimate, that is the bulk of that fan-out removed in steady state, while a user action still refreshes instantly via the tx invalidation.

## Regression
typecheck ✅ · eslint ✅ · production build ✅. No test runner in repo.

## Staleness budget
Reserves ≤ 12 s, user reserves ≤ 30 s, and **immediately** after the user's own supply/borrow/repay/withdraw (explicit invalidation). Well within a sensible dashboard refresh budget.
