### PR TITLE
add shellfish to hydration RPC providers

### DIFF
--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -65,6 +65,7 @@ export const PROVIDERS: ProviderProps[] = [
   createProvider("coke", "wss://rpc.coke.hydration.cloud"),
   createProvider("kril", "wss://node-dir.kril.hydration.cloud"),
   createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
+  createProvider("shellfish", "wss://hdx.shellfish.hydration.cloud"),
   // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
   createProvider(
     "Testnet",


### PR DESCRIPTION
## Summary
- Add `wss://hdx.shellfish.hydration.cloud` to the RPC provider list under the GC-internal nodes group.

The shellfish node is a fresh archive-canonical full-sync Hydration RPC running on the shellfish.hydration.cloud host (HE Hetzner box, 64-core EPYC, 7T raid10). Currently at tip, peers stable, `--rpc-methods=safe`, parachain bootstrapped against tarn as a peer hint.

## Test plan
- [ ] Switch RPC to "shellfish" in the UI's provider selector
- [ ] Confirm app loads, balances + pool data populate
- [ ] Confirm a simple read RPC call works