### PR TITLE
rpc: route fleet nodes through their caching subways

### DIFF
--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -53,19 +53,10 @@ export const SQUID_URLS: IndexerProps[] = SQUID_URLS_CONFIG.map((config) => ({
 }))
 
 export const PROVIDERS: ProviderProps[] = [
-  createProvider("Dwellir", "wss://hydration-rpc.n.dwellir.com"),
-  //createProvider("Dotters", "wss://hydration.dotters.network"),
-  // createProvider("LATAM", "wss://hydration.rpc.stkd.io"),
-  createProvider("Rotko (SEA)", "wss://hydration.rotko.net"),
-  // createProvider("zipp", "wss://rpc.zipp.hydration.cloud"),
-  // createProvider("roach", "wss://rpc.roach.hydration.cloud"),
-  // createProvider("lait", "wss://rpc.lait.hydration.cloud"),
-  //createProvider("parm", "wss://rpc.parm.hydration.cloud"),
-  createProvider("sin", "wss://rpc.sin.hydration.cloud"),
-  createProvider("coke", "wss://rpc.coke.hydration.cloud"),
-  createProvider("kril", "wss://node-dir.kril.hydration.cloud"),
-  createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
-  // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
+  createProvider("coke", "wss://subway.coke.hydration.cloud"),
+  createProvider("sin", "wss://subway.sin.hydration.cloud"),
+  createProvider("tarn", "wss://subway.tarn.hydration.cloud"),
+  createProvider("shellfish", "wss://subway.shellfish.hydration.cloud"),
   createProvider(
     "Testnet",
     "wss://rpc.nice.hydration.cloud",

--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -65,6 +65,10 @@ export const PROVIDERS: ProviderProps[] = [
   createProvider("coke", "wss://subway.coke.hydration.cloud"),
   createProvider("kril", "wss://rpc.kril.hydration.cloud"),
   createProvider("shellfish", "wss://subway.shellfish.hydration.cloud"),
+  createProvider("catfish-1", "wss://rpc-catfish-1.catfish.hydration.cloud"),
+  createProvider("catfish-2", "wss://rpc-catfish-2.catfish.hydration.cloud"),
+  createProvider("catfish-3", "wss://rpc-catfish-3.catfish.hydration.cloud"),
+  createProvider("catfish-4", "wss://rpc-catfish-4.catfish.hydration.cloud"),
   createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
   // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
   createProvider(

--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -53,10 +53,19 @@ export const SQUID_URLS: IndexerProps[] = SQUID_URLS_CONFIG.map((config) => ({
 }))
 
 export const PROVIDERS: ProviderProps[] = [
-  createProvider("coke", "wss://subway.coke.hydration.cloud"),
+  createProvider("Dwellir", "wss://hydration-rpc.n.dwellir.com"),
+  //createProvider("Dotters", "wss://hydration.dotters.network"),
+  // createProvider("LATAM", "wss://hydration.rpc.stkd.io"),
+  createProvider("Rotko (SEA)", "wss://hydration.rotko.net"),
+  // createProvider("zipp", "wss://rpc.zipp.hydration.cloud"),
+  // createProvider("roach", "wss://rpc.roach.hydration.cloud"),
+  // createProvider("lait", "wss://rpc.lait.hydration.cloud"),
+  //createProvider("parm", "wss://rpc.parm.hydration.cloud"),
   createProvider("sin", "wss://subway.sin.hydration.cloud"),
-  createProvider("tarn", "wss://subway.tarn.hydration.cloud"),
-  createProvider("shellfish", "wss://subway.shellfish.hydration.cloud"),
+  createProvider("coke", "wss://subway.coke.hydration.cloud"),
+  createProvider("kril", "wss://node-dir.kril.hydration.cloud"),
+  createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
+  // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
   createProvider(
     "Testnet",
     "wss://rpc.nice.hydration.cloud",

--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -63,7 +63,7 @@ export const PROVIDERS: ProviderProps[] = [
   //createProvider("parm", "wss://rpc.parm.hydration.cloud"),
   createProvider("sin", "wss://subway.sin.hydration.cloud"),
   createProvider("coke", "wss://subway.coke.hydration.cloud"),
-  createProvider("kril", "wss://node-dir.kril.hydration.cloud"),
+  createProvider("kril", "wss://rpc.kril.hydration.cloud"),
   createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
   // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
   createProvider(

--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -64,6 +64,7 @@ export const PROVIDERS: ProviderProps[] = [
   createProvider("sin", "wss://subway.sin.hydration.cloud"),
   createProvider("coke", "wss://subway.coke.hydration.cloud"),
   createProvider("kril", "wss://rpc.kril.hydration.cloud"),
+  createProvider("shellfish", "wss://subway.shellfish.hydration.cloud"),
   createProvider("sparrow", "wss://node-sparrow-1.sparrow.shadow-senate.com"),
   // createProvider("owl", "wss://rpc-owl-1.owl.shadow-senate.com"),
   createProvider(


### PR DESCRIPTION
## What

Point the operator nodes that sit behind a caching subway at their subway endpoint:

```
sin:        wss://rpc.sin.hydration.cloud       → wss://subway.sin.hydration.cloud
coke:       wss://rpc.coke.hydration.cloud      → wss://subway.coke.hydration.cloud
kril:       wss://node-dir.kril.hydration.cloud → wss://rpc.kril.hydration.cloud
shellfish:  (new)                               → wss://subway.shellfish.hydration.cloud
catfish-1..4: (new)                             → wss://rpc-catfish-{1..4}.catfish.hydration.cloud
```

All run the legacy-caching subway config validated in #3898 (advertise legacy `state_*`, no `chainHead_*`, cache `state_getReadProof`), each fronting its own node. All verified live (synced, serving legacy method set).

Unchanged: external providers (Dwellir, Rotko), sparrow (no subway), Testnet/Paseo.
