### PR TITLE
feat: add Unified aggregation indexer as third squid pool

### DIFF
--- a/apps/main/src/config/rpc.ts
+++ b/apps/main/src/config/rpc.ts
@@ -44,6 +44,10 @@ export const SQUID_URLS_CONFIG = [
     name: "Catfish",
     url: "https://orca-prod-pool-02.catfish.hydration.cloud",
   },
+  {
+    name: "Unified",
+    url: "https://unified-main-aggr-indx.indexer.hydration.cloud",
+  },
 ]
 
 export const SQUID_URLS: IndexerProps[] = SQUID_URLS_CONFIG.map((config) => ({


### PR DESCRIPTION
Adds `unified-main-aggr-indx.indexer.hydration.cloud` to `SQUID_URLS_CONFIG`, making the unified (shellfish) aggregation indexer a third option in the auto-mode indexer picker alongside Orca and Catfish.

## Why

- Until 2026-07-14/15 the squid picker had zero redundancy in practice: Orca pool-01 was down (API OOM crash-loop) and unified — the default `MAINNET_SQUID_URL` — had been frozen since 07-09, leaving Catfish alone. All three are now healthy; this PR lets the picker actually use all of them.
- Unified has the deepest history of the three (indexed from block 1,439,857 vs Catfish's 5,000,001).

## Readiness (verified live)

- `/rest/service/metadata` — served as of image `65d053f2` (endpoint added in `hydration-data-lake` branch `fix/agg-ind-615-metadata-endpoint`, deployed 2026-07-15), same response shape as the other pools.
- `LatestBlockHeightQuery` (edges syntax) answers at chain head.
- CORS (`access-control-allow-origin: *`) via the indexer-proxy alias — the direct shellfish hostname does NOT serve CORS headers, hence the alias URL.
- Swarm-level healthcheck + auto-restart deployed on the backing service.

Reports `master: false` in metadata, so `getBestIndexer` prefers Orca/Catfish on ties and unified acts as depth/fallback capacity.