### PR TITLE
Use registry asset id for metadata lookups in xcm transfer

### DIFF
--- a/apps/main/src/modules/xcm/transfer/XcmForm.tsx
+++ b/apps/main/src/modules/xcm/transfer/XcmForm.tsx
@@ -156,7 +156,7 @@ export const XcmForm = () => {
   const hasValidAccounts = isConnectedAccountValid && !!destAddress
 
   const spotPriceId = srcAsset
-    ? registryChain.getBalanceAssetId(srcAsset).toString()
+    ? registryChain.getAssetId(srcAsset).toString()
     : undefined
 
   const { price } = useAssetPrice(spotPriceId)

--- a/apps/main/src/modules/xcm/transfer/components/ChainAssetSelect/AssetList.tsx
+++ b/apps/main/src/modules/xcm/transfer/components/ChainAssetSelect/AssetList.tsx
@@ -39,7 +39,7 @@ export const AssetList: React.FC<AssetListProps> = ({
 }) => {
   const priceIds = useMemo(() => {
     return items.map((item) => {
-      const registryId = registryChain.getBalanceAssetId(item.asset)
+      const registryId = registryChain.getAssetId(item.asset)
       return registryId.toString()
     })
   }, [items, registryChain])
@@ -65,7 +65,7 @@ export const AssetList: React.FC<AssetListProps> = ({
     if (isLoadingBalances || isAssetPriceLoading) return items
 
     const assetsWithBalances = items.map((item) => {
-      const registryId = registryChain.getBalanceAssetId(item.asset)
+      const registryId = registryChain.getAssetId(item.asset)
       const balance = balances?.get(item.asset.key)
       const { price } = getAssetPrice(registryId.toString())
       return {

--- a/apps/main/src/modules/xcm/transfer/components/ChainAssetSelect/AssetListItem.tsx
+++ b/apps/main/src/modules/xcm/transfer/components/ChainAssetSelect/AssetListItem.tsx
@@ -51,7 +51,7 @@ export const AssetListItem: React.FC<AssetListItemProps> = ({
   const { t } = useTranslation(["common"])
   const { getAsset } = useAssets()
 
-  const registryId = registryChain.getBalanceAssetId(asset)
+  const registryId = registryChain.getAssetId(asset)
   const registryAsset = getAsset(registryId.toString())
 
   const meta = registryAsset

--- a/apps/main/src/modules/xcm/transfer/components/XAssetLogo/XAssetLogo.tsx
+++ b/apps/main/src/modules/xcm/transfer/components/XAssetLogo/XAssetLogo.tsx
@@ -33,7 +33,7 @@ export const XAssetLogo: React.FC<XAssetLogoProps> = ({
     )
   }
 
-  const registryId = registryChain.getBalanceAssetId(asset)
+  const registryId = registryChain.getAssetId(asset)
   const registryAsset = getAsset(registryId.toString())
 
   return (


### PR DESCRIPTION
The xcm transfer module resolves registry metadata (logos, prices, symbol/name) through `registryChain.getBalanceAssetId()`. That returns the balance-query id, which diverges from the registry id for any asset that defines a `balanceId` — e.g. erc20-backed assets whose balances are read from a contract address. The registry lookup then receives a `0x…` address instead of the asset id and misses, rendering a "?" logo and no price.

Switches the five call sites to `registryChain.getAssetId()`, which is the chain-internal registry id these lookups actually want.

Surfaced while testing the HOLLAR ↔ AssetHub routes (galacticcouncil/sdk#343): HOLLAR carries `balanceId: 0x531a…` (GHO contract) for balance reads, and every metadata lookup in the transfer form broke. With this change the HOLLAR icon and spot price resolve correctly from asset 222. No behavior change for existing assets — on the hydration registry chain, `getAssetId` and `getBalanceAssetId` are identical wherever `balanceId` is unset.