### PR TITLE
bil: queue reads via public-var getters (queue-fills upgrade compat)

### DIFF
--- a/apps/main/src/modules/strategies/bil/constants.ts
+++ b/apps/main/src/modules/strategies/bil/constants.ts
@@ -209,13 +209,10 @@ export const VAULT_ABI = [
     stateMutability: "view",
   },
   // Redemption queue -----------------------------------------------------
-  {
-    type: "function",
-    name: "getRedemptionQueueLength",
-    inputs: [],
-    outputs: [{ name: "", type: "uint256" }],
-    stateMutability: "view",
-  },
+  // getRedemptionQueueLength/getQueueHead/getTotalQueuedBil/getIdleHollar
+  // were dropped from the vault in the queue-fills upgrade (EIP-170 diet);
+  // the public storage vars are the getters now. They exist on the
+  // pre-upgrade vault too, so these reads work on both sides.
   {
     type: "function",
     name: "getRedemptionQueuePending",
@@ -225,7 +222,7 @@ export const VAULT_ABI = [
   },
   {
     type: "function",
-    name: "getQueueHead",
+    name: "queueHead",
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
     stateMutability: "view",
@@ -257,14 +254,14 @@ export const VAULT_ABI = [
   },
   {
     type: "function",
-    name: "getTotalQueuedBil",
+    name: "totalQueuedBil",
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
     stateMutability: "view",
   },
   {
     type: "function",
-    name: "getIdleHollar",
+    name: "idleHollar",
     inputs: [],
     outputs: [{ name: "", type: "uint256" }],
     stateMutability: "view",

--- a/apps/main/src/modules/strategies/bil/hooks/useRedemptionQueue.ts
+++ b/apps/main/src/modules/strategies/bil/hooks/useRedemptionQueue.ts
@@ -40,9 +40,9 @@ export function useRedemptionQueue(evmAddress: Hex | undefined) {
       if (!vault) throw new Error("Vault contract not found")
 
       const [length, head, totalQueued] = await Promise.all([
-        vault.read.getRedemptionQueueLength(),
-        vault.read.getQueueHead(),
-        vault.read.getTotalQueuedBil(),
+        vault.read.queueTail(),
+        vault.read.queueHead(),
+        vault.read.totalQueuedBil(),
       ])
 
       const queueLength = Number(length)

--- a/apps/main/src/modules/strategies/bil/hooks/useVaultReads.ts
+++ b/apps/main/src/modules/strategies/bil/hooks/useVaultReads.ts
@@ -78,8 +78,8 @@ export function useVaultStats() {
         vault.read.minReinvestAmount(),
         vault.read.minRedeemAmount(),
         vault.read.getAPYWad(),
-        vault.read.getRedemptionQueueLength(),
-        vault.read.getIdleHollar(),
+        vault.read.queueTail(),
+        vault.read.idleHollar(),
         vault.read.getPositionCount(),
         vault.read.getPositionHead(),
       ])


### PR DESCRIPTION
Companion to money-market#50 (queue fills). The vault's EIP-170 diet drops four explicit getters; this repoints the UI at the public storage vars, which exist on both the current and the upgraded vault — safe to merge any time, before or after the upgrade enacts.

- `getRedemptionQueueLength` → `queueTail`, `getQueueHead` → `queueHead`, `getTotalQueuedBil` → `totalQueuedBil`, `getIdleHollar` → `getIdleHollar`→`idleHollar` (ABI + `useRedemptionQueue` + `useVaultReads`)
- verified live against node0.lark's pre-upgrade vault: all four respond
- `getPosition`/`getRedemptionRequest` untouched — the upgrade only appends static return fields, which viem's decoder ignores

Sell-early UI (listing/asks) is NOT here — that lands with the upgrade rollout per QUEUE-FILLS-SPEC.md §9.6.