### PR TITLE
mm: fix inflated hollar max borrow

### DIFF
--- a/packages/money-market/src/hooks/app-data-provider/useAppDataProvider.tsx
+++ b/packages/money-market/src/hooks/app-data-provider/useAppDataProvider.tsx
@@ -146,6 +146,7 @@ export const AppDataProvider: React.FC<{
     )
 
     if (
+      formattedGhoUserData.userGhoDiscountPercent > 0 &&
       formattedGhoUserData.userDiscountedGhoInterest > 0 &&
       marketReferenceCurrencyPriceInUsd.gt(0)
     ) {


### PR DESCRIPTION
For HOLLAR borrowers with accrued interest, the UI treated that interest as if it had been discounted away — even when the account had no HOLLAR borrow discount.

That made:

- Available to borrow too high — interest was incorrectly added back into borrowing power
- Total debt too low — the same interest was stripped out of “total borrowed,” which also nudged portfolio borrow APY slightly
Fix

Only apply the discount adjustment when the user actually has a discount. No discount → show full debt and real remaining borrow capacity.