### PR TITLE
Schedule split-trade buy as a sell order

### DIFF
--- a/apps/main/src/api/trade.ts
+++ b/apps/main/src/api/trade.ts
@@ -22,7 +22,6 @@ export type TradeOrder = sor.TradeOrder
 export type TxBuilderFactory = SdkCtx["tx"]
 export type TradeRouter = sor.TradeRouter
 
-export const TradeOrderType = sor.TradeOrderType
 export const TradeOrderError = sor.TradeOrderError
 
 type BestSellArgs = {
@@ -350,116 +349,6 @@ export const bestBuyWithTxQuery = (
       }
     },
     enabled: bestBuy.enabled as boolean,
-  })
-}
-
-type BestBuyTwapArgs = Omit<BestBuyArgs, "debug">
-
-export const bestBuyTwapQuery = (
-  { sdk, isApiLoaded }: TProviderContext,
-  { assetIn, assetOut, amountOut }: BestBuyTwapArgs,
-  enabled = true,
-) =>
-  queryOptions({
-    queryKey: [
-      QUERY_KEY_BLOCK_PREFIX,
-      "trade",
-      "twapBuyOrder",
-      assetIn,
-      assetOut,
-      amountOut,
-    ],
-    queryFn: async () =>
-      sdk.api.scheduler.getTwapBuyOrder(
-        Number(assetIn),
-        Number(assetOut),
-        amountOut,
-      ),
-    enabled:
-      enabled &&
-      isApiLoaded &&
-      !!assetIn &&
-      !!assetOut &&
-      Big(amountOut || "0").gt(0),
-  })
-
-export const bestBuyTwapTxQuery = (
-  { sdk }: TProviderContext,
-  twap: TradeOrder,
-  twapKey: QueryKey,
-  address: string,
-  slippage: number,
-  maxRetries: number,
-) =>
-  queryOptions({
-    queryKey: [twapKey, "tx"],
-    queryFn: () =>
-      sdk.tx
-        .order(twap)
-        .withSlippage(slippage)
-        .withMaxRetries(maxRetries)
-        .withBeneficiary(address)
-        .build()
-        .then((tx) => tx.get()),
-    enabled: !!address,
-  })
-
-type BestBuyTwapWithTxArgs = BestBuyTwapArgs & {
-  readonly slippage: number
-  readonly address: string
-  readonly maxRetries: number
-  readonly dryRun?: boolean
-}
-
-export const bestBuyTwapWithTxQuery = (
-  rpc: TProviderContext,
-  {
-    slippage,
-    maxRetries,
-    address,
-    dryRun,
-    ...bestBuyTwapArgs
-  }: BestBuyTwapWithTxArgs,
-  enabled = true,
-) => {
-  const { queryClient } = rpc
-  const bestBuyTwap = bestBuyTwapQuery(rpc, bestBuyTwapArgs)
-
-  return queryOptions({
-    queryKey: [
-      QUERY_KEY_BLOCK_PREFIX,
-      bestBuyTwap.queryKey,
-      slippage,
-      maxRetries,
-      address,
-      dryRun,
-    ],
-    queryFn: async () => {
-      const twap = await queryClient.ensureQueryData(bestBuyTwap)
-
-      const txQuery = bestBuyTwapTxQuery(
-        rpc,
-        twap,
-        bestBuyTwap.queryKey,
-        address,
-        slippage,
-        maxRetries,
-      )
-
-      const tx = txQuery.enabled
-        ? await queryClient.ensureQueryData(txQuery)
-        : null
-
-      const dryRunError =
-        tx && dryRun && ENV.VITE_DRY_RUN_ENABLED
-          ? await queryClient.ensureQueryData(
-              papiDryRunErrorQuery(rpc, address, tx),
-            )
-          : null
-
-      return { twap, tx, dryRunError }
-    },
-    enabled: enabled && (bestBuyTwap.enabled as boolean),
   })
 }
 

--- a/apps/main/src/modules/trade/swap/components/TradeOption/TradeOption.tsx
+++ b/apps/main/src/modules/trade/swap/components/TradeOption/TradeOption.tsx
@@ -14,7 +14,6 @@ type Props = {
   readonly active: boolean
   readonly value: string
   readonly diff?: string
-  readonly isBuy?: boolean
   readonly onClick: () => void
   readonly disabled?: boolean
 }
@@ -26,7 +25,6 @@ export const TradeOption = ({
   active,
   value,
   diff,
-  isBuy,
   onClick,
   disabled,
 }: Props) => {
@@ -55,13 +53,9 @@ export const TradeOption = ({
               fs="p6"
               fw={600}
               color={
-                isBuy
-                  ? isPositive
-                    ? getToken("accents.danger.emphasis")
-                    : getToken("accents.success.emphasis")
-                  : isPositive
-                    ? getToken("accents.success.emphasis")
-                    : getToken("accents.danger.emphasis")
+                isPositive
+                  ? getToken("accents.success.emphasis")
+                  : getToken("accents.danger.emphasis")
               }
             >
               ({isPositive && "+"}

--- a/apps/main/src/modules/trade/swap/sections/Market/Market.BuyData.ts
+++ b/apps/main/src/modules/trade/swap/sections/Market/Market.BuyData.ts
@@ -1,14 +1,15 @@
 import { useAccount } from "@galacticcouncil/web3-connect"
-import { useQueries, useQuery } from "@tanstack/react-query"
+import { keepPreviousData, useQueries, useQuery } from "@tanstack/react-query"
 import { UseFormReturn } from "react-hook-form"
 import { useDebounce } from "use-debounce"
 
 import { healthFactorQuery } from "@/api/aave"
-import { bestBuyQuery, bestBuyTwapQuery } from "@/api/trade"
+import { bestBuyQuery, bestSellTwapQuery } from "@/api/trade"
 import { isTwapEnabled } from "@/modules/trade/swap/sections/Market/lib/isTwapEnabled"
 import { TradeProviderProps } from "@/modules/trade/swap/sections/Market/lib/tradeProvider"
 import { MarketFormValues } from "@/modules/trade/swap/sections/Market/lib/useMarketForm"
 import { useRpcProvider } from "@/providers/rpcProvider"
+import { scaleHuman } from "@/utils/formatting"
 
 export const useMarketBuyData = (
   form: UseFormReturn<MarketFormValues>,
@@ -48,24 +49,34 @@ export const useMarketBuyData = (
     ],
   })
 
-  const { data: twap, isLoading: isTwapLoading } = useQuery(
-    bestBuyTwapQuery(
+  // The chain no longer accepts buy schedules, so a buy intent is scheduled as
+  // a sell of what the buy quote says it costs
+  const twapBudget =
+    swap && sellAsset ? scaleHuman(swap.amountIn, sellAsset.decimals) : ""
+
+  const { data: twap, isLoading: isTwapLoading } = useQuery({
+    ...bestSellTwapQuery(
       rpc,
       {
         assetIn: sellAsset?.id ?? "",
         assetOut: buyAsset?.id ?? "",
-        amountOut: debouncedBuyAmount,
+        amountIn: twapBudget,
       },
       isTwapEnabled(swap),
     ),
-  )
+    // The budget is part of the query key, so every quote move would otherwise
+    // drop the order back to a skeleton. Without a budget there is nothing to
+    // hold on to, so the form collapses as it did before.
+    placeholderData: twapBudget ? keepPreviousData : undefined,
+  })
 
   return {
     swap,
     twap,
     healthFactor: healthFactorData,
     isSwapLoading,
-    isTwapLoading,
+    // The order query only starts once the quote it is budgeted from resolves
+    isTwapLoading: isSwapLoading || isTwapLoading,
     isHealthFactorLoading,
   }
 }

--- a/apps/main/src/modules/trade/swap/sections/Market/MarketTradeOptions.tsx
+++ b/apps/main/src/modules/trade/swap/sections/Market/MarketTradeOptions.tsx
@@ -6,13 +6,7 @@ import { FC } from "react"
 import { Controller, useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 
-import {
-  Trade,
-  TradeOrder,
-  tradeOrderDurationQuery,
-  TradeOrderType,
-  TradeType,
-} from "@/api/trade"
+import { Trade, TradeOrder, tradeOrderDurationQuery } from "@/api/trade"
 import { TradeOption } from "@/modules/trade/swap/components/TradeOption/TradeOption"
 import { TradeOptionSkeleton } from "@/modules/trade/swap/components/TradeOption/TradeOptionSkeleton"
 import { MarketFormValues } from "@/modules/trade/swap/sections/Market/lib/useMarketForm"
@@ -55,11 +49,10 @@ export const MarketTradeOptions: FC<Props> = ({
     return null
   }
 
-  const isBuy = swap.type === TradeType.Buy
-
-  const [asset, amount, twapAmount] = isBuy
-    ? [sellAsset, swap.amountIn, twap?.amountIn]
-    : [buyAsset, swap.amountOut, twap?.amountOut]
+  // Both options spend the same amount, so what separates them is what comes
+  // back; a buy quote's output is the amount that was asked for
+  const asset = buyAsset
+  const [amount, twapAmount] = [swap.amountOut, twap?.amountOut]
 
   const price = scaleHuman(amount, asset.decimals)
   const twapPrice = twapAmount ? scaleHuman(twapAmount, asset.decimals) : "0"
@@ -88,7 +81,6 @@ export const MarketTradeOptions: FC<Props> = ({
               asset={asset}
               value={twapPrice}
               diff={diff}
-              isBuy={twap.type === TradeOrderType.TwapBuy}
               active={!field.value}
               onClick={(): void => {
                 field.onChange(false)

--- a/apps/main/src/modules/trade/swap/sections/Market/MarketTradeOptions.tsx
+++ b/apps/main/src/modules/trade/swap/sections/Market/MarketTradeOptions.tsx
@@ -49,13 +49,8 @@ export const MarketTradeOptions: FC<Props> = ({
     return null
   }
 
-  // Both options spend the same amount, so what separates them is what comes
-  // back; a buy quote's output is the amount that was asked for
-  const asset = buyAsset
-  const [amount, twapAmount] = [swap.amountOut, twap?.amountOut]
-
-  const price = scaleHuman(amount, asset.decimals)
-  const twapPrice = twapAmount ? scaleHuman(twapAmount, asset.decimals) : "0"
+  const price = scaleHuman(swap.amountOut, buyAsset.decimals)
+  const twapPrice = twap ? scaleHuman(twap.amountOut, buyAsset.decimals) : "0"
   const diff = Big(twapPrice).minus(price).toString()
 
   return (
@@ -65,7 +60,7 @@ export const MarketTradeOptions: FC<Props> = ({
       render={({ field }) => (
         <Flex sx={{ flexDirection: "column", gap: "base" }}>
           <TradeOption
-            asset={asset}
+            asset={buyAsset}
             value={price}
             active={field.value}
             onClick={(): void => {
@@ -78,7 +73,7 @@ export const MarketTradeOptions: FC<Props> = ({
             <TradeOptionSkeleton />
           ) : (
             <TradeOption
-              asset={asset}
+              asset={buyAsset}
               value={twapPrice}
               diff={diff}
               active={!field.value}

--- a/apps/main/src/modules/trade/swap/sections/Market/MarketWarnings.tsx
+++ b/apps/main/src/modules/trade/swap/sections/Market/MarketWarnings.tsx
@@ -104,6 +104,7 @@ export const MarketWarnings: FC<Props> = ({
   }
 
   const shouldRenderSlippageWarning =
+    isFormValid &&
     Number(isSingleTrade ? swapSlippage : twapSlippage) < validSlippage
 
   const shouldRenderHealthFactorWarning =

--- a/apps/main/src/modules/trade/swap/sections/Market/Summary/MarketSummaryTwap.tsx
+++ b/apps/main/src/modules/trade/swap/sections/Market/Summary/MarketSummaryTwap.tsx
@@ -16,7 +16,6 @@ import { FC } from "react"
 import { useFormContext } from "react-hook-form"
 import { useTranslation } from "react-i18next"
 
-import { TradeOrderType } from "@/api/trade"
 import { calculateSlippage } from "@/api/utils/slippage"
 import { useDisplayAssetPrice } from "@/components/AssetPrice"
 import { DynamicFee } from "@/components/DynamicFee"
@@ -68,8 +67,9 @@ export const MarketSummaryTwap: FC<Props> = ({ swap, twap, healthFactor }) => {
     useTwapFee(twap)
   const transactionCosts = transactionFee?.feeEstimate || "0"
 
-  const isBuy = twap.type === TradeOrderType.TwapBuy
-  const tradeFeeAsset = isBuy ? sellAsset : buyAsset
+  // Every twap executes as a sell, so the received side carries the fee and
+  // the price protection
+  const tradeFeeAsset = buyAsset
   const tradeFee = tradeFeeAsset
     ? scaleHuman(twap.tradeFee, tradeFeeAsset.decimals)
     : "0"
@@ -94,17 +94,6 @@ export const MarketSummaryTwap: FC<Props> = ({ swap, twap, healthFactor }) => {
       return [0n, 0n, "0", null]
     }
 
-    if (twap.type === TradeOrderType.TwapBuy) {
-      const twapPrice =
-        twap.amountIn + calculateSlippage(twap.amountIn, twapSlippage)
-      const twapPriceHuman = scaleHuman(twapPrice, sellAsset.decimals)
-
-      const swapPrice =
-        swap.amountIn + calculateSlippage(swap.amountIn, swapSlippage)
-
-      return [twapPrice, swapPrice, twapPriceHuman, sellAsset]
-    }
-
     const twapPrice =
       twap.amountOut - calculateSlippage(twap.amountOut, twapSlippage)
     const twapPriceHuman = scaleHuman(twapPrice, buyAsset.decimals)
@@ -122,7 +111,7 @@ export const MarketSummaryTwap: FC<Props> = ({ swap, twap, healthFactor }) => {
     return null
   }
 
-  const tradeAmount = isBuy ? twap.amountIn : twap.amountOut
+  const tradeAmount = twap.amountOut
 
   const tradeFeePct = Big(twap.tradeFee.toString())
     .div(tradeAmount.toString())
@@ -160,16 +149,8 @@ export const MarketSummaryTwap: FC<Props> = ({ swap, twap, healthFactor }) => {
             priceImpact={swap.priceImpactPct}
           />
           <CalculatedAmountSummaryRow
-            label={
-              isBuy
-                ? t("trade:market.summary.maxSent")
-                : t("trade:market.summary.minReceived")
-            }
-            tooltip={
-              isBuy
-                ? t("trade:market.summary.maxSent.tooltip")
-                : t("trade:market.summary.minReceived.tooltip")
-            }
+            label={t("trade:market.summary.minReceived")}
+            tooltip={t("trade:market.summary.minReceived.tooltip")}
             amount={
               <SummaryRowValue>
                 <span>


### PR DESCRIPTION
Split-trade buy on the swap page was the only producer of buy schedules.
Buy mode already resolves `bestBuyQuery` before gating the TWAP query, so
`swap.amountIn` — the exact cost of the typed target — is in hand. That cost
is now scheduled as a sell via `bestSellTwapQuery`. No extra round trip.

The user still types a target and still sees the cost in the sell field. The
order now spends that cost exactly and receives approximately the target,
rather than receiving the target exactly and spending up to
`cost x (1 + slippage)`. Per-trade protection is
`min_amount_out = tradeAmountOut x (1 - slippage)`, same as sell-mode TWAP.
`tradeCount` now derives from sell-direction price impact.

Also removes the dead buy-TWAP cluster in `api/trade.ts` and the
`TradeOrderType` re-export, which reference SDK APIs slated for removal.
